### PR TITLE
Set 'appium:platformVersion' capability from 'device.sdk'

### DIFF
--- a/src/CapabilityManager.ts
+++ b/src/CapabilityManager.ts
@@ -21,10 +21,11 @@ export async function androidCapabilities(
 
 export async function iOSCapabilities(
   caps: ISessionCapability,
-  freeDevice: { udid: any; name: string; realDevice: boolean; mjpegServerPort?: number }
+  freeDevice: { udid: any; name: string; realDevice: boolean; sdk: string, mjpegServerPort?: number }
 ) {
   caps.firstMatch[0]['appium:udid'] = freeDevice.udid;
   caps.firstMatch[0]['appium:deviceName'] = freeDevice.name;
+  caps.firstMatch[0]['appium:platformVersion'] = freeDevice.sdk;
   caps.firstMatch[0]['appium:wdaLocalPort'] = await getPort();
   if (!isCapabilityAlreadyPresent(caps, 'appium:mjpegServerPort')) {
     if (freeDevice.realDevice) {


### PR DESCRIPTION
Closes #457 

This makes sure platformVersion is set when creating session otherwise, XCUITestDriver warns "[XCUITestDriver@1706] 'platformVersion' capability ('undefined') is not a valid version number. Consider fixing it or be ready to experience an inconsistent driver behavior." while creatingSession raises exception