### PR TITLE
Change CLI argument `include-simulators` to `device-types`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ These arguments are set when you launch the Appium server, with this plugin inst
 |Argument|Required|Description|Default|Options|
 |----|---|----------|------|-------|
 |`plugin-device-farm-platform`| Yes | Platform to run tests against for parallel execution | None | `both`,`ios`,`android` |
-|`plugin-device-farm-include-simulators`| No | Whether or not to include simulators along with real devices | `true` |`true`, `false`|
+|`plugin-device-farm-device-types`| No | Types of devices to include | `both` |`both`,`simulated`,`real`|
 |`plugin-device-farm-remote`| No | Whether or not to include simulators/real devices from remote machine | None |`remote: ["http://remotehost:remoteport"]`, If you want to run tests distributed across remote and local machine `remote: ["http://remotehost:remoteport", "http://127.0.0.1"]`|
 
 ## Capabilities

--- a/package.json
+++ b/package.json
@@ -115,8 +115,9 @@
         "platform": {
           "type": "string"
         },
-        "include-simulators": {
-          "type": "boolean"
+        "device-types": {
+          "type": "string",
+          "default": "both"
         },
         "remote": {
           "type": "array"

--- a/remote-config.json
+++ b/remote-config.json
@@ -4,7 +4,7 @@
       "plugin": {
         "device-farm": {
           "platform": "android",
-          "include-simulators": true
+          "device-types": "both"
         }
       }
     }

--- a/src/device-managers/AndroidDeviceManager.ts
+++ b/src/device-managers/AndroidDeviceManager.ts
@@ -22,10 +22,23 @@ export default class AndroidDeviceManager implements IDeviceManager {
     const hosts = cliArgs.plugin['device-farm'].remote;
     try {
       for (const host of hosts) {
+        let devices: Array<IDevice>;
         if (!isObject(host) && host.includes('127.0.0.1')) {
-          return await this.fetchLocalAndroidDevices(deviceState, existingDeviceDetails, cliArgs);
+          devices = await this.fetchLocalAndroidDevices(deviceState, existingDeviceDetails, cliArgs);
         } else {
-          return await this.fetchRemoteAndroidDevices(host, deviceState, 'android');
+          devices = await this.fetchRemoteAndroidDevices(host, deviceState, 'android');
+        }
+        if (deviceTypes === "real") {
+          return devices.filter((device) => {
+            return device.deviceType === "real";
+          });
+        } else if (deviceTypes === "simulated") {
+          return devices.filter((device) => {
+            return device.deviceType === "emulator";
+          });
+        // return both real and simulated (emulated) devices
+        } else {
+          return devices;
         }
       }
     } catch (e) {

--- a/src/device-managers/AndroidDeviceManager.ts
+++ b/src/device-managers/AndroidDeviceManager.ts
@@ -11,7 +11,7 @@ export default class AndroidDeviceManager implements IDeviceManager {
   private adbAvailable = true;
 
   async getDevices(
-    includeSimulators: boolean,
+    deviceTypes: string,
     existingDeviceDetails: Array<IDevice>,
     cliArgs: any
   ): Promise<any> {

--- a/src/device-managers/IOSDeviceManager.ts
+++ b/src/device-managers/IOSDeviceManager.ts
@@ -16,22 +16,25 @@ export default class IOSDeviceManager implements IDeviceManager {
    * @returns {Promise<Array<IDevice>>}
    */
   async getDevices(
-    includeSimulators: boolean,
+    deviceTypes: string,
     existingDeviceDetails: Array<IDevice>,
     cliArgs: any
   ): Promise<IDevice[]> {
     if (!isMac()) {
       return [];
     } else {
-      if (includeSimulators) {
+      if (deviceTypes === "real") {
+        return flatten(await Promise.all([this.getRealDevices(existingDeviceDetails, cliArgs)]));
+      } else if (deviceTypes === "simulated") {
+        return flatten(await Promise.all([this.getSimulators(cliArgs)]));
+      // return both real and simulated devices
+      } else {
         return flatten(
           await Promise.all([
             this.getRealDevices(existingDeviceDetails, cliArgs),
             this.getSimulators(cliArgs),
           ])
         );
-      } else {
-        return flatten(await Promise.all([this.getRealDevices(existingDeviceDetails, cliArgs)]));
       }
     }
   }

--- a/src/device-managers/index.ts
+++ b/src/device-managers/index.ts
@@ -6,19 +6,19 @@ import IOSDeviceManager from './IOSDeviceManager';
 
 export class DeviceFarmManager {
   private deviceManagers: Array<IDeviceManager> = [];
-  private includeSimulators: boolean;
+  private deviceTypes: string;
   private cliArgs: any;
 
   constructor({
     platform,
-    includeSimulators,
+    deviceTypes,
     cliArgs,
   }: {
     platform: Platform | 'both';
-    includeSimulators: boolean | true;
+    deviceTypes: string | 'both';
     cliArgs: any;
   }) {
-    this.includeSimulators = includeSimulators;
+    this.deviceTypes = deviceTypes;
     this.cliArgs = cliArgs;
     if (platform === 'both') {
       this.deviceManagers.push(new AndroidDeviceManager());
@@ -35,7 +35,7 @@ export class DeviceFarmManager {
     for (const deviceManager of this.deviceManagers) {
       devices.push(
         ...(await deviceManager.getDevices(
-          this.includeSimulators,
+          this.deviceTypes,
           existingDeviceDetails || [],
           this.cliArgs
         ))

--- a/src/interfaces/IDeviceManager.ts
+++ b/src/interfaces/IDeviceManager.ts
@@ -2,7 +2,7 @@ import { IDevice } from './IDevice';
 
 export interface IDeviceManager {
   getDevices(
-    includeSimulators: boolean,
+    deviceTypes: string,
     existingDeviceDetails: Array<IDevice>,
     cliArgs: any
   ): Promise<IDevice[]>;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -59,7 +59,7 @@ class DevicePlugin extends BasePlugin {
         '🔴 🔴 🔴 Specify --plugin-device-farm-platform from CLI as android,iOS or both or use appium server config. Please refer 🔗 https://github.com/appium/appium/blob/master/packages/appium/docs/en/guides/config.md 🔴 🔴 🔴'
       );
     if (!remote) cliArgs.plugin['device-farm'].remote = ['http://127.0.0.1'];
-    DevicePlugin.setIncludeSimulatorState(cliArgs, deviceTypes);
+    deviceTypes = DevicePlugin.setIncludeSimulatorState(cliArgs, deviceTypes);
     const deviceManager = new DeviceFarmManager({
       platform,
       deviceTypes,
@@ -82,6 +82,7 @@ class DevicePlugin extends BasePlugin {
       cloudExists[0].cloudName === Cloud.BROWSERSTACK ? (deviceTypes = "real") : true;
     if (deviceTypes === "real")
       logger.info('ℹ️ Skipping Simulators as per the configuration ℹ️');
+    return deviceTypes;
   }
 
   private static async waitForRemoteServerToBeRunning(cliArgs: any) {

--- a/test/integration/androidDevices.spec.js
+++ b/test/integration/androidDevices.spec.js
@@ -9,7 +9,7 @@ describe('Android Test', () => {
   it('Allocate free device and verify the device state is busy in db', async () => {
     const deviceManager = new DeviceFarmManager({
       platform: 'android',
-      includeSimulators: true,
+      deviceTypes: 'both',
       cliArgs: { port: 4723, plugin: { 'device-farm': { remote: ['http://127.0.0.1:4723'] } } },
     });
     Container.set(DeviceFarmManager, deviceManager);
@@ -31,7 +31,7 @@ describe('Android Test', () => {
   it('Allocate second free device and verify both the device state is busy in db', async () => {
     const deviceManager = new DeviceFarmManager({
       platform: 'android',
-      includeSimulators: true,
+      deviceTypes: 'both',
       cliArgs: { port: 4723, plugin: { 'device-farm': { remote: ['http://127.0.0.1:4723'] } } },
     });
     Container.set(DeviceFarmManager, deviceManager);
@@ -53,7 +53,7 @@ describe('Android Test', () => {
   it('Finding a device should throw error when all devices are busy', async () => {
     const deviceManager = new DeviceFarmManager({
       platform: 'android',
-      includeSimulators: true,
+      deviceTypes: 'both',
       cliArgs: { port: 4723, plugin: { 'device-farm': { remote: ['http://127.0.0.1:4723'] } } },
     });
     Container.set(DeviceFarmManager, deviceManager);

--- a/test/integration/iOSDevices.spec.js
+++ b/test/integration/iOSDevices.spec.js
@@ -8,7 +8,7 @@ describe('IOS Test', () => {
   it('Throw error when no device is found for given capabilities', async () => {
     const deviceManager = new DeviceFarmManager({
       platform: 'iOS',
-      includeSimulators: true,
+      deviceTypes: 'both',
       cliArgs: { port: 4723, plugin: '' },
     });
     Container.set(DeviceFarmManager, deviceManager);

--- a/test/integration/iOSSimulator.spec.js
+++ b/test/integration/iOSSimulator.spec.js
@@ -14,7 +14,7 @@ describe('IOS Simulator Test', () => {
   it('Should find free iPhone simulator when app path has .app extension and set busy status to true', async () => {
     const deviceManager = new DeviceFarmManager({
       platform: 'ios',
-      includeSimulators: true,
+      deviceTypes: 'both',
       cliArgs: { port: 4723, plugin: { 'device-farm': { remote: ['http://127.0.0.1:4723'] } } },
     });
     Container.set(DeviceFarmManager, deviceManager);
@@ -40,7 +40,7 @@ describe('IOS Simulator Test', () => {
   it('Should find free iPad simulator when app path has .app extension and set busy status to true', async () => {
     const deviceManager = new DeviceFarmManager({
       platform: 'ios',
-      includeSimulators: true,
+      deviceTypes: 'both',
       cliArgs: { port: 4723, plugin: { 'device-farm': { remote: ['http://127.0.0.1:4723'] } } },
     });
     Container.set(DeviceFarmManager, deviceManager);
@@ -75,7 +75,7 @@ describe('Boot simulator test', async () => {
   it('Should pick Booted simulator when app path has .app', async () => {
     const deviceManager = new DeviceFarmManager({
       platform: 'ios',
-      includeSimulators: true,
+      deviceTypes: 'both',
       cliArgs: { port: 4723, plugin: { 'device-farm': { remote: ['http://127.0.0.1:4723'] } } }, 
     });
     Container.set(DeviceFarmManager, deviceManager);

--- a/test/unit/AndroidDeviceManager.spec.js
+++ b/test/unit/AndroidDeviceManager.spec.js
@@ -37,6 +37,159 @@ describe('Android Device Manager', () => {
         platform: 'android',
         systemPort: 54321,
         host: 'http://127.0.0.1:4723',
+      }
+    ]);
+  });
+
+  it('Android Device List to have added state - Include simulators with real devices', async () => {
+    const androidDevices = new AndroidDeviceManager();
+    sandbox.stub(androidDevices, 'fetchLocalAndroidDevices').returns(
+      [
+        {
+          busy: false,
+          name: 'sdk_phone_x86',
+          state: 'device',
+          deviceType: 'emulator',
+          sdk: '9',
+          realDevice: false,
+          udid: 'emulator-5554',
+          platform: 'android',
+          systemPort: 54321,
+          host: 'http://127.0.0.1:4723',
+        },
+        {
+          busy: false,
+          name: 'Nexus 6',
+          state: 'device',
+          deviceType: 'real',
+          sdk: '9',
+          realDevice: true,
+          udid: 'YOGAA1BBB4124',
+          platform: 'android',
+          systemPort: 54322,
+          host: 'http://127.0.0.1:4723',
+        },
+      ]
+    );
+    const devices = await androidDevices.getDevices("both", [], { port: 4723, plugin: cliArgs });
+    expect(devices).to.deep.equal([
+      {
+        busy: false,
+        name: 'sdk_phone_x86',
+        state: 'device',
+        deviceType: 'emulator',
+        sdk: '9',
+        realDevice: false,
+        udid: 'emulator-5554',
+        platform: 'android',
+        systemPort: 54321,
+        host: 'http://127.0.0.1:4723',
+      },
+      {
+        busy: false,
+        name: 'Nexus 6',
+        state: 'device',
+        deviceType: 'real',
+        sdk: '9',
+        realDevice: true,
+        udid: 'YOGAA1BBB4124',
+        platform: 'android',
+        systemPort: 54322,
+        host: 'http://127.0.0.1:4723',
+      },
+    ]);
+  });
+
+  it('Android Device List to have added state - Only emulators', async () => {
+    const androidDevices = new AndroidDeviceManager();
+    sandbox.stub(androidDevices, 'fetchLocalAndroidDevices').returns(
+      [
+        {
+          busy: false,
+          name: 'sdk_phone_x86',
+          state: 'device',
+          deviceType: 'emulator',
+          sdk: '9',
+          realDevice: false,
+          udid: 'emulator-5554',
+          platform: 'android',
+          systemPort: 54321,
+          host: 'http://127.0.0.1:4723',
+        },
+        {
+          busy: false,
+          name: 'Nexus 6',
+          state: 'device',
+          deviceType: 'real',
+          sdk: '9',
+          realDevice: true,
+          udid: 'YOGAA1BBB4124',
+          platform: 'android',
+          systemPort: 54322,
+          host: 'http://127.0.0.1:4723',
+        },
+      ]
+    );
+    const devices = await androidDevices.getDevices("simulated", [], { port: 4723, plugin: cliArgs });
+    expect(devices).to.deep.equal([
+      {
+        busy: false,
+        name: 'sdk_phone_x86',
+        state: 'device',
+        deviceType: 'emulator',
+        sdk: '9',
+        realDevice: false,
+        udid: 'emulator-5554',
+        platform: 'android',
+        systemPort: 54321,
+        host: 'http://127.0.0.1:4723',
+      }
+    ]);
+  });
+
+  it('Android Device List to have added state - Only real devices', async () => {
+    const androidDevices = new AndroidDeviceManager();
+    sandbox.stub(androidDevices, 'fetchLocalAndroidDevices').returns(
+      [
+        {
+          busy: false,
+          name: 'sdk_phone_x86',
+          state: 'device',
+          deviceType: 'emulator',
+          sdk: '9',
+          realDevice: false,
+          udid: 'emulator-5554',
+          platform: 'android',
+          systemPort: 54321,
+          host: 'http://127.0.0.1:4723',
+        },
+        {
+          busy: false,
+          name: 'Nexus 6',
+          state: 'device',
+          deviceType: 'real',
+          sdk: '9',
+          realDevice: true,
+          udid: 'YOGAA1BBB4124',
+          platform: 'android',
+          systemPort: 54322,
+          host: 'http://127.0.0.1:4723',
+        },
+      ]
+    );
+    const devices = await androidDevices.getDevices("real", [], { port: 4723, plugin: cliArgs });
+    expect(devices).to.deep.equal([
+      {
+        busy: false,
+        name: 'Nexus 6',
+        state: 'device',
+        deviceType: 'real',
+        sdk: '9',
+        realDevice: true,
+        udid: 'YOGAA1BBB4124',
+        platform: 'android',
+        systemPort: 54322,
+        host: 'http://127.0.0.1:4723',
       },
     ]);
   });

--- a/test/unit/AndroidDeviceManager.spec.js
+++ b/test/unit/AndroidDeviceManager.spec.js
@@ -7,7 +7,7 @@ var sandbox = sinon.createSandbox();
 const cliArgs = {
   'device-farm': {
     platform: 'android',
-    'include-simulators': true,
+    'device-types': 'both',
     remote: ['http://127.0.0.1:4723'],
   },
 };

--- a/test/unit/AndroidDeviceManager.spec.js
+++ b/test/unit/AndroidDeviceManager.spec.js
@@ -24,7 +24,7 @@ describe('Android Device Manager', () => {
     sandbox.stub(androidDevices, 'getDeviceName').returns('sdk_phone_x86');
     sandbox.stub(androidDevices, 'isRealDevice').returns(false);
     sandbox.stub(Helper, 'getFreePort').returns(54321);
-    const devices = await androidDevices.getDevices(true, [], { port: 4723, plugin: cliArgs });
+    const devices = await androidDevices.getDevices("both", [], { port: 4723, plugin: cliArgs });
     expect(devices).to.deep.equal([
       {
         busy: false,

--- a/test/unit/IOSDeviceManager.spec.js
+++ b/test/unit/IOSDeviceManager.spec.js
@@ -40,7 +40,7 @@ describe('IOS Device Manager', () => {
         host: 'http://127.0.0.1:4723',
       },
     ]);
-    const devices = await iosDevices.getDevices(true, [], { port: 4723, plugin: cliArgs });
+    const devices = await iosDevices.getDevices("both", [], { port: 4723, plugin: cliArgs });
     expect(devices).to.deep.equal([
       {
         udid: '00001111-00115D822222002E',
@@ -88,7 +88,7 @@ describe('IOS Device Manager', () => {
         host: 'http://127.0.0.1:4723',
       },
     ]);
-    const devices = await iosDevices.getDevices(true, [], { port: 4723, plugin: cliArgs });
+    const devices = await iosDevices.getDevices("both", [], { port: 4723, plugin: cliArgs });
     expect(devices).to.deep.equal([
       {
         udid: '00001111-00115D822222002E',
@@ -128,7 +128,7 @@ describe('IOS Device Manager', () => {
         host: 'http://127.0.0.1:4723',
       },
     ]);
-    const devices = await iosDevices.getDevices(false, [], { port: 4723, plugin: cliArgs });
+    const devices = await iosDevices.getDevices("real", [], { port: 4723, plugin: cliArgs });
     expect(devices).to.deep.equal([
       {
         udid: '00001111-00115D822222002E',

--- a/test/unit/IOSDeviceManager.spec.js
+++ b/test/unit/IOSDeviceManager.spec.js
@@ -112,6 +112,36 @@ describe('IOS Device Manager', () => {
     ]);
   });
 
+  it('IOS Device List to have added state - Only simulators', async () => {
+    const iosDevices = new IOSDeviceManager();
+    sandbox.stub(iosDevices, 'getConnectedDevices').returns(['00001111-00115D822222002E']);
+    sandbox.stub(iosDevices, 'getOSVersion').returns('14.1.1');
+    sandbox.stub(iosDevices, 'getDeviceName').returns('Sai’s iPhone');
+    sandbox.stub(Helper, 'getFreePort').returns(54093);
+    sandbox.stub(iosDevices, 'getSimulators').returns([
+      {
+        name: 'iPad Air (3rd generation)',
+        udid: '0FBCBDCC-2FF1-4FCA-B034-60ABC86ED866',
+        state: 'Shutdown',
+        sdk: '13.5',
+        platform: 'ios',
+        host: 'http://127.0.0.1:4723',
+      },
+    ]);
+    const devices = await iosDevices.getDevices("simulated", [], { port: 4723, plugin: cliArgs });
+    expect(devices).to.deep.equal([
+      {
+        name: 'iPad Air (3rd generation)',
+        udid: '0FBCBDCC-2FF1-4FCA-B034-60ABC86ED866',
+        state: 'Shutdown',
+        sdk: '13.5',
+        platform: 'ios',
+        host: 'http://127.0.0.1:4723',
+      },
+    ]);
+  });
+
+
   it('IOS Device List to have added state - Only real devices', async () => {
     const iosDevices = new IOSDeviceManager();
     sandbox.stub(iosDevices, 'getConnectedDevices').returns(['00001111-00115D822222002E']);

--- a/test/unit/IOSDeviceManager.spec.js
+++ b/test/unit/IOSDeviceManager.spec.js
@@ -7,7 +7,7 @@ var sandbox = sinon.createSandbox();
 const cliArgs = {
   'device-farm': {
     platform: 'iOS',
-    'include-simulators': true,
+    'device-types': 'both',
     remote: ['http://127.0.0.1:4723'],
   },
 };

--- a/test/unit/RemoteIOs.spec.js
+++ b/test/unit/RemoteIOs.spec.js
@@ -10,7 +10,7 @@ const ipAddress = ip.address();
 const cliArgs = {
   'device-farm': {
     platform: 'iOS',
-    'include-simulators': true,
+    'device-types': 'both',
     remote: [`http://${ipAddress}:3000`, 'http://127.0.0.1:4723'],
   },
 };

--- a/test/unit/RemoteIOs.spec.js
+++ b/test/unit/RemoteIOs.spec.js
@@ -86,7 +86,7 @@ describe('Remote IOS', () => {
           host: 'http://127.0.0.1:4723',
         },
       ]);
-    const devices = await iosDevices.getDevices(true, [], { port: 4723, plugin: cliArgs });
+    const devices = await iosDevices.getDevices("both", [], { port: 4723, plugin: cliArgs });
     const expected = [
       {
         wdaLocalPort: 54093,


### PR DESCRIPTION
Closes #455 
Closes #516 

This changes CLI argument `include-simulators` to `--plugin-device-farm-device-types=both(default)|simulated|real`, allowing someone to specify which types of devices they want to appear in the device farm