### PR TITLE
Respect 'appium:newCommandTimeout' capability when releasing inactive devices

### DIFF
--- a/src/data-service/device-service.ts
+++ b/src/data-service/device-service.ts
@@ -125,5 +125,6 @@ export function unblockDevice(sessionId: string) {
       device.lastCmdExecutedAt = undefined;
       device.sessionStartTime = 0;
       device.totalUtilizationTimeMilliSec = totalUtilization;
+      device.newCommandTimeout = undefined;
     });
 }

--- a/src/interfaces/IDevice.ts
+++ b/src/interfaces/IDevice.ts
@@ -18,5 +18,6 @@ export interface IDevice {
   lastCmdExecutedAt?: number;
   totalUtilizationTimeMilliSec: number;
   sessionStartTime: number;
+  newCommandTimeout?: number;
   cloud?: any;
 }


### PR DESCRIPTION
Closes #529 

These changes honor 'appium:newCommandTimeout' capability otherwise defaults to 60 seconds to match Appium before releasing device due to inactivity