### PR TITLE
Set unique derivedDataPath and mjpegServerPort for each iOS device

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appium-device-farm",
-  "version": "2.0.0-beta.9",
+  "version": "2.0.0-beta.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "appium-device-farm",
-      "version": "2.0.0-beta.9",
+      "version": "2.0.0-beta.10",
       "license": "ISC",
       "dependencies": {
         "@appium/base-plugin": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-device-farm",
-  "version": "2.0.0-beta.9",
+  "version": "2.0.0-beta.10",
   "description": "An appium 2.0 plugin that manages and create driver session on available devices",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/CapabilityManager.ts
+++ b/src/CapabilityManager.ts
@@ -35,26 +35,17 @@ export async function iOSCapabilities(
     sdk: string;
     mjpegServerPort?: number;
     wdaLocalPort?: number;
+    derivedDataPath?: string;
   }
 ) {
   caps.firstMatch[0]['appium:udid'] = freeDevice.udid;
   caps.firstMatch[0]['appium:deviceName'] = freeDevice.name;
   caps.firstMatch[0]['appium:platformVersion'] = freeDevice.sdk;
   caps.firstMatch[0]['appium:wdaLocalPort'] = freeDevice.wdaLocalPort;
-  if (!isCapabilityAlreadyPresent(caps, 'appium:mjpegServerPort')) {
-    if (freeDevice.realDevice) {
-      caps.firstMatch[0]['appium:mjpegServerPort'] = await getPort();
-    } else {
-      /* In simulator, port forwarding won't happen for each session. So mjpegServerPort will be used only for 1st time.
-       * So set the port for the first time and resuse the same port for subsequent sessions.
-       */
-      const existingPort = freeDevice.mjpegServerPort;
-      caps.firstMatch[0]['appium:mjpegServerPort'] =
-        existingPort && (await isPortBusy(existingPort)) ? existingPort : await getPort();
-    }
-    deleteAlwaysMatch(caps, 'appium:mjpegServerPort');
-    deleteAlwaysMatch(caps, 'appium:udid');
-    deleteAlwaysMatch(caps, 'appium:deviceName');
-    deleteAlwaysMatch(caps, 'appium:wdaLocalPort');
-  }
+  caps.firstMatch[0]['appium:mjpegServerPort'] = freeDevice.mjpegServerPort;
+  caps.firstMatch[0]['appium:derivedDataPath'] = freeDevice.derivedDataPath;
+  deleteAlwaysMatch(caps, 'appium:mjpegServerPort');
+  deleteAlwaysMatch(caps, 'appium:udid');
+  deleteAlwaysMatch(caps, 'appium:deviceName');
+  deleteAlwaysMatch(caps, 'appium:wdaLocalPort');
 }

--- a/src/device-managers/IOSDeviceManager.ts
+++ b/src/device-managers/IOSDeviceManager.ts
@@ -8,6 +8,9 @@ import { asyncForEach } from '../helpers';
 import log from '../logger';
 import axios from 'axios';
 import { DeviceFactory } from './factory/DeviceFactory';
+import os from 'os';
+import path from 'path';
+import getPort from 'get-port';
 
 export default class IOSDeviceManager implements IDeviceManager {
   /**
@@ -94,10 +97,12 @@ export default class IOSDeviceManager implements IDeviceManager {
       } else {
         log.info(`IOS Device details for ${udid} not available. So querying now.`);
         const wdaLocalPort = await getFreePort();
+        const mjpegServerPort = await getPort();
         const [sdk, name] = await Promise.all([this.getOSVersion(udid), this.getDeviceName(udid)]);
         deviceState.push(
           Object.assign({
             wdaLocalPort,
+            mjpegServerPort,
             udid,
             sdk,
             name,
@@ -108,6 +113,7 @@ export default class IOSDeviceManager implements IDeviceManager {
             totalUtilizationTimeMilliSec: 0,
             sessionStartTime: 0,
             host: `http://127.0.0.1:${cliArgs.port}`,
+            derivedDataPath: path.join(os.homedir(), `Library/Developer/Xcode/DerivedData/WebDriverAgent-${udid}`)
           })
         );
       }
@@ -155,10 +161,12 @@ export default class IOSDeviceManager implements IDeviceManager {
     );
     await asyncForEach(flattenValued, async (device: IDevice) => {
       const wdaLocalPort = await getFreePort();
+      const mjpegServerPort = await getPort();
       simulators.push(
         Object.assign({
           ...device,
           wdaLocalPort,
+          mjpegServerPort,
           busy: false,
           realDevice: false,
           platform: 'ios',
@@ -166,6 +174,7 @@ export default class IOSDeviceManager implements IDeviceManager {
           totalUtilizationTimeMilliSec: 0,
           sessionStartTime: 0,
           host: `http://127.0.0.1:${cliArgs.port}`,
+          derivedDataPath: path.join(os.homedir(), `Library/Developer/Xcode/DerivedData/WebDriverAgent-${device.udid}`)
         })
       );
     });

--- a/src/device-managers/IOSDeviceManager.ts
+++ b/src/device-managers/IOSDeviceManager.ts
@@ -10,7 +10,6 @@ import axios from 'axios';
 import { DeviceFactory } from './factory/DeviceFactory';
 import os from 'os';
 import path from 'path';
-import getPort from 'get-port';
 
 export default class IOSDeviceManager implements IDeviceManager {
   /**
@@ -97,7 +96,7 @@ export default class IOSDeviceManager implements IDeviceManager {
       } else {
         log.info(`IOS Device details for ${udid} not available. So querying now.`);
         const wdaLocalPort = await getFreePort();
-        const mjpegServerPort = await getPort();
+        const mjpegServerPort = await getFreePort();
         const [sdk, name] = await Promise.all([this.getOSVersion(udid), this.getDeviceName(udid)]);
         deviceState.push(
           Object.assign({
@@ -161,7 +160,7 @@ export default class IOSDeviceManager implements IDeviceManager {
     );
     await asyncForEach(flattenValued, async (device: IDevice) => {
       const wdaLocalPort = await getFreePort();
-      const mjpegServerPort = await getPort();
+      const mjpegServerPort = await getFreePort();
       simulators.push(
         Object.assign({
           ...device,

--- a/src/device-utils.ts
+++ b/src/device-utils.ts
@@ -103,9 +103,6 @@ export async function updateCapabilityForDevice(capability: any, device: IDevice
   if (!device.hasOwnProperty('cloud')) {
     if (device.platform.toLowerCase() == DevicePlatform.IOS) {
       await iOSCapabilities(capability, device);
-      updateDevice(device, {
-        mjpegServerPort: capability.firstMatch[0]['appium:mjpegServerPort'],
-      });
     } else {
       await androidCapabilities(capability, device);
     }

--- a/src/interfaces/IDevice.ts
+++ b/src/interfaces/IDevice.ts
@@ -20,4 +20,5 @@ export interface IDevice {
   sessionStartTime: number;
   newCommandTimeout?: number;
   cloud?: any;
+  derivedDataPath?: string;
 }

--- a/test/unit/IOSDeviceManager.spec.js
+++ b/test/unit/IOSDeviceManager.spec.js
@@ -2,6 +2,8 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 import IOSDeviceManager from '../../src/device-managers/IOSDeviceManager';
 import * as Helper from '../../src/helpers';
+import os from 'os';
+import path from 'path';
 var sandbox = sinon.createSandbox();
 
 const cliArgs = {
@@ -55,9 +57,12 @@ describe('IOS Device Manager', () => {
         deviceType: 'real',
         platform: 'ios',
         wdaLocalPort: 54093,
+        mjpegServerPort: 50686,
         sessionStartTime: 0,
         totalUtilizationTimeMilliSec: 0,
         host: 'http://127.0.0.1:4723',
+        derivedDataPath: path.join(os.homedir(), 'Library/Developer/Xcode/DerivedData/WebDriverAgent-00001111-00115D822222002E'),
+        mjpegServerPort: 54093
       },
       {
         name: 'iPad Air (3rd generation)',
@@ -114,6 +119,8 @@ describe('IOS Device Manager', () => {
         sessionStartTime: 0,
         totalUtilizationTimeMilliSec: 0,
         host: 'http://127.0.0.1:4723',
+        derivedDataPath: path.join(os.homedir(), 'Library/Developer/Xcode/DerivedData/WebDriverAgent-00001111-00115D822222002E'),
+        mjpegServerPort: 54093
       },
       {
         name: 'iPad Air (3rd generation)',
@@ -194,6 +201,8 @@ describe('IOS Device Manager', () => {
         sessionStartTime: 0,
         totalUtilizationTimeMilliSec: 0,
         host: 'http://127.0.0.1:4723',
+        derivedDataPath: path.join(os.homedir(), 'Library/Developer/Xcode/DerivedData/WebDriverAgent-00001111-00115D822222002E'),
+        mjpegServerPort: 54093
       },
     ]);
   });

--- a/test/unit/RemoteIOs.spec.js
+++ b/test/unit/RemoteIOs.spec.js
@@ -4,6 +4,8 @@ import IOSDeviceManager from '../../src/device-managers/IOSDeviceManager';
 import * as Helper from '../../src/helpers';
 import { expect } from 'chai';
 import axios from 'axios';
+import os from 'os';
+import path from 'path';
 let sandbox = Sinon.createSandbox();
 const firstNode = ip.address();
 const secondNode = ip.address();
@@ -100,6 +102,8 @@ describe('Remote IOS', () => {
         sessionStartTime: 0,
         totalUtilizationTimeMilliSec: 0,
         host: 'http://127.0.0.1:4723',
+        derivedDataPath: path.join(os.homedir(), 'Library/Developer/Xcode/DerivedData/WebDriverAgent-00001111-00115D822222002E'),
+        mjpegServerPort: 54093
       },
       {
         name: 'iPad (8th generation)',


### PR DESCRIPTION
I've been noticing that the parallelization of sessions is pretty slow for the real iOS devices I'm testing on. Appium recommends setting unique values for `udid`, `wdaLocalPort`, `derivedDataPath`, `mjpegServerPort`
https://github.com/appium/appium-xcuitest-driver#important-real-device-capabilities

I noticed a couple of issues, before the changes in this branch:

1. The `mjpegServerPort` is incorrect on subsequent runs. If you use the port from the first session, you can view the video. The change in this branch sets it once for each device and leaves it as-is (similar to the `wdaLocalPort`)
2. The `derivedDataPath` is not getting set so the WebDriverAgent seems to be getting built more than it needs to. Setting it as a unique path for each device makes parallel execution faster