### PR TITLE
Support platformVersion capability when filtering devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ These arguments are set when you launch the Appium server, with this plugin inst
 | appium:deviceAvailabilityTimeout | When create session requests are more than available connected devices, plugin waits for a certain interval for device availability before it timeout. Default value is `180000` milliseconds. |
 | appium:deviceRetryInterval       | When create session requests are more than available connected devices, plugin polls for device availability in certain intervals. Default value is `10000` milliseconds.                      |
 | appium:udids                     | Comma separated list of device udid's to execute tests only on specific devices `appium:udids: device1UDID,device2UDID` |
+| appium:platformVersion           | This capability is used to filter devices/simulators based on SDK. Only devices/simulators that are an exact match with the platformVerson would be considered for test run. `appium:platformVersion` is optional argument. ex: `'appium:platformVersion': 16.1.1`   |
 | appium:minSDK                    | This capability is used to filter devices/simulators based on SDK. Devices/Simulators with SDK greater then or equal to minSDK would only be considered for test run. `appium:minSDK` is optional argument. ex: `'appium:minSDK': 15`   |
 
 # Custom chrome binary url

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appium-device-farm",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "appium-device-farm",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "ISC",
       "dependencies": {
         "@appium/base-plugin": "1.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-device-farm",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "An appium 2.0 plugin that manages and create driver session on available devices",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/data-service/device-service.ts
+++ b/src/data-service/device-service.ts
@@ -70,6 +70,10 @@ export function getDevice(filterOptions: IDeviceFilterOptions): IDevice {
     busy: filterOptions.busy,
   } as any;
 
+  if (filterOptions.platformVersion) {
+    filter.sdk = filterOptions.platformVersion;
+  }
+
   if (filterOptions.udid) {
     filter.udid = { $in: filterOptions.udid };
   }

--- a/src/device-utils.ts
+++ b/src/device-utils.ts
@@ -186,6 +186,7 @@ export function getDeviceFiltersFromCapability(capability: any): IDeviceFilterOp
   }
   return {
     platform,
+    platformVersion: capability['appium:platformVersion'] ? capability['appium:platformVersion'] : undefined,
     name,
     deviceType,
     udid: udids?.length ? udids : undefined,

--- a/src/interfaces/IDeviceFilterOptions.ts
+++ b/src/interfaces/IDeviceFilterOptions.ts
@@ -3,6 +3,7 @@ import { DeviceType } from '../types/DeviceType';
 
 export interface IDeviceFilterOptions {
   platform?: Platform;
+  platformVersion?: string;
   name?: string;
   busy?: boolean;
   offline?: boolean;

--- a/test/unit/device-service.spec.js
+++ b/test/unit/device-service.spec.js
@@ -86,4 +86,40 @@ describe('Get device', () => {
     const device = getDevice(filterOptions);
     expect(parseFloat(device.sdk)).to.be.gte(14.1);
   });
+
+  it('Get android device based on filter with platformVersion', () => {
+    const filterOptions = {
+      platform: 'android',
+      name: '',
+      busy: false,
+      offline: false,
+      platformVersion: "10",
+    };
+    const device = getDevice(filterOptions);
+    expect(device.sdk).to.be.eql('10');
+  });
+
+  it('Get ios simulator based on filter with platformVersion', () => {
+    const filterOptions = { platform: 'ios', name: '', busy: false, offline: false, platformVersion: "14.0" };
+    const device = getDevice(filterOptions);
+    expect(device.sdk).to.be.eql('14.0');
+  });
+
+  it('Get android device returns undefined based on filter with platformVersion', () => {
+    const filterOptions = {
+      platform: 'android',
+      name: '',
+      busy: false,
+      offline: false,
+      platformVersion: "9",
+    };
+    const device = getDevice(filterOptions);
+    expect(device).to.be.undefined;
+  });
+
+  it('Get ios simulator returns undefined based on filter with platformVersion', () => {
+    const filterOptions = { platform: 'ios', name: '', busy: false, offline: false, platformVersion: "16.0" };
+    const device = getDevice(filterOptions);
+    expect(device).to.be.undefined;
+  });
 });

--- a/test/unit/plugin.spec.js
+++ b/test/unit/plugin.spec.js
@@ -8,6 +8,7 @@ describe('Device filter tests', () => {
         platformName: 'iOS',
         'appium:app': '/Downloads/VodQA.ipa',
         'appium:iPhoneOnly': true,
+        'appium:platformVersion': '14.0'
       },
       firstMatch: [{}],
     };
@@ -15,6 +16,7 @@ describe('Device filter tests', () => {
     const filter = getDeviceFiltersFromCapability(firstMatch);
     expect(filter).to.deep.equal({
       platform: 'ios',
+      platformVersion: '14.0',
       name: 'iPhone',
       deviceType: 'real',
       udid: undefined,
@@ -29,6 +31,7 @@ describe('Device filter tests', () => {
         platformName: 'iOS',
         'appium:app': '/Downloads/VodQA.app',
         'appium:iPhoneOnly': true,
+        'appium:platformVersion': '14.0'
       },
       firstMatch: [{}],
     };
@@ -36,6 +39,7 @@ describe('Device filter tests', () => {
     const filter = getDeviceFiltersFromCapability(firstMatch);
     expect(filter).to.deep.equal({
       platform: 'ios',
+      platformVersion: '14.0',
       name: 'iPhone',
       deviceType: 'simulator',
       udid: undefined,
@@ -58,6 +62,7 @@ describe('Device filter tests', () => {
     const filter = getDeviceFiltersFromCapability(firstMatch);
     expect(filter).to.deep.equal({
       platform: 'ios',
+      platformVersion: undefined,
       name: 'iPhone',
       deviceType: 'simulator',
       udid: undefined,


### PR DESCRIPTION
I'd like to be able to target devices with a specific sdk (`appium:platformVersion`).

I tried to use `appium:minSDK` while adding `appium:maxSDK` however found this to not work when device sdk couldn't be casted to a number (e.g. `16.1.1`).

So the easiest  way to support my workflow was to consider `platformVersion` when filtering devices by capability 