### PR TITLE
Fix tvOS capabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appium-device-farm",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "appium-device-farm",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
         "@appium/base-plugin": "1.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-device-farm",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "An appium 2.0 plugin that manages and create driver session on available devices",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/device-utils.ts
+++ b/src/device-utils.ts
@@ -111,10 +111,10 @@ export async function allocateDeviceForSession(capability: ISessionCapability): 
 
 export async function updateCapabilityForDevice(capability: any, device: IDevice) {
   if (!device.hasOwnProperty('cloud')) {
-    if (device.platform.toLowerCase() == DevicePlatform.IOS) {
-      await iOSCapabilities(capability, device);
-    } else {
+    if (device.platform.toLowerCase() == DevicePlatform.ANDROID) {
       await androidCapabilities(capability, device);
+    } else {
+      await iOSCapabilities(capability, device);
     }
   } else {
     logger.info('Updating cloud Capability for Device');


### PR DESCRIPTION
I missed this in the first tvOS PR https://github.com/AppiumTestDistribution/appium-device-farm/pull/603

Both iOS and tvOS device platforms should use the iOSCapabilities as they both use the XCUITest driver