### PR TITLE
Add maxSDK capability + semantic version filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Above cli arguments can also be set from config.json file Refer [here](https://g
 | appium:platformName              | Requests asession for the provided platform name. Valid options are `iOS`, `tvOS`, or `Android`, ex: `'appium:platformName': tvOS`   |
 | appium:platformVersion           | This capability is used to filter devices/simulators based on SDK. Only devices/simulators that are an exact match with the platformVerson would be considered for test run. `appium:platformVersion` is optional argument. ex: `'appium:platformVersion': 16.1.1`   |
 | appium:minSDK                    | This capability is used to filter devices/simulators based on SDK. Devices/Simulators with SDK greater then or equal to minSDK would only be considered for test run. `appium:minSDK` is optional argument. ex: `'appium:minSDK': 15`   |
+| appium:maxSDK                    | This capability is used to filter devices/simulators based on SDK. Devices/Simulators with SDK less then or equal to maxSDK would only be considered for test run. `appium:maxSDK` is optional argument. ex: `'appium:maxSDK': 15`   |
 
 # Custom chrome binary url
 set the new URL to `CHROMEDRIVER_CDNURL` environment variable:

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "ora": "5.4.1",
         "ramda": "^0.28.0",
         "reflect-metadata": "^0.1.13",
+        "semver": "^7.3.8",
         "tcp-port-used": "^1.0.2",
         "typedi": "^0.10.0",
         "uuid": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "get-port": "^5.1.1",
     "go-ios": "^1.0.101",
     "http-proxy-middleware": "^2.0.6",
+    "ip": "^1.1.8",
     "lodash": "^4.17.21",
     "lokijs": "^1.5.12",
     "node-abort-controller": "^3.1.1",
@@ -80,11 +81,11 @@
     "ora": "5.4.1",
     "ramda": "^0.28.0",
     "reflect-metadata": "^0.1.13",
+    "semver": "^7.3.8",
     "tcp-port-used": "^1.0.2",
     "typedi": "^0.10.0",
     "uuid": "^8.3.2",
-    "yargs": "^17.5.1",
-    "ip": "^1.1.8"
+    "yargs": "^17.5.1"
   },
   "peerDependencies": {
     "appium": "^2.0.0-beta.44"

--- a/src/data-service/device-service.ts
+++ b/src/data-service/device-service.ts
@@ -68,7 +68,7 @@ export function getDevice(filterOptions: IDeviceFilterOptions): IDevice {
     });
   }
 
-  if (semver.coerce(filterOptions.maxSDK) !== null) {
+  if (semver.coerce(filterOptions.maxSDK)) {
     results = results.where(function(obj: IDevice) {
       if (semver.coerce(obj.sdk)) {
         return semver.lte(semver.coerce(obj.sdk), semver.coerce(filterOptions.maxSDK));

--- a/src/data-service/device-service.ts
+++ b/src/data-service/device-service.ts
@@ -56,6 +56,27 @@ export function getAllDevices(): Array<IDevice> {
 }
 
 export function getDevice(filterOptions: IDeviceFilterOptions): IDevice {
+  const semver = require('semver');
+  var results = DeviceModel.chain();
+
+  if (semver.coerce(filterOptions.minSDK)) {
+    results = results.where(function(obj: IDevice) {
+      if (semver.coerce(obj.sdk)) {
+        return semver.gte(semver.coerce(obj.sdk), semver.coerce(filterOptions.minSDK));
+      }
+      return false;
+    });
+  }
+
+  if (semver.coerce(filterOptions.maxSDK) !== null) {
+    results = results.where(function(obj: IDevice) {
+      if (semver.coerce(obj.sdk)) {
+        return semver.lte(semver.coerce(obj.sdk), semver.coerce(filterOptions.maxSDK));
+      }
+      return false;
+    });
+  }
+
   const filter = {
     platform: filterOptions.platform,
     name: { $contains: filterOptions.name || '' },
@@ -70,20 +91,17 @@ export function getDevice(filterOptions: IDeviceFilterOptions): IDevice {
     filter.udid = { $in: filterOptions.udid };
   }
 
-  if (filterOptions.minSDK) {
-    filter.sdk = { $gte: filterOptions.minSDK };
-  }
-
   if (filterOptions.deviceType === 'simulator') {
     filter.state = 'Booted';
-    if (DeviceModel.chain().find(filter).data()[0] != undefined) {
+    if (results.find(filter).data()[0] != undefined) {
       logger.info('Picking up booted simulator');
-      return DeviceModel.chain().find(filter).data()[0];
+      return results.find(filter).data()[0];
     } else {
       filter.state = 'Shutdown';
     }
-  }
-  return DeviceModel.chain().find(filter).data()[0];
+  }  
+
+  return results.find(filter).data()[0];
 }
 
 export function updatedAllocatedDevice(device: IDevice, updateData: Partial<IDevice>) {

--- a/src/device-utils.ts
+++ b/src/device-utils.ts
@@ -39,6 +39,7 @@ const customCapability = {
   ipadOnly: 'appium:iPadOnly',
   udids: 'appium:udids',
   minSDK: 'appium:minSDK',
+  maxSDK: 'appium:maxSDK'
 };
 
 let timer: any;
@@ -233,6 +234,7 @@ export function getDeviceFiltersFromCapability(capability: any): IDeviceFilterOp
     busy: false,
     userBlocked: false,
     minSDK: capability[customCapability.minSDK] ? capability[customCapability.minSDK] : undefined,
+    maxSDK: capability[customCapability.maxSDK] ? capability[customCapability.maxSDK] : undefined,
   };
 }
 

--- a/src/interfaces/IDeviceFilterOptions.ts
+++ b/src/interfaces/IDeviceFilterOptions.ts
@@ -10,5 +10,6 @@ export interface IDeviceFilterOptions {
   userBlocked?: boolean;
   udid?: any[];
   deviceType?: DeviceType;
-  minSDK: number;
+  minSDK: string;
+  maxSDK: string;
 }

--- a/test/unit/device-service.spec.js
+++ b/test/unit/device-service.spec.js
@@ -86,16 +86,53 @@ describe('Get device', () => {
       name: '',
       busy: false,
       offline: false,
-      minSDK: 10.8,
+      minSDK: '10.0.1',
     };
     const device = getDevice(filterOptions);
-    expect(parseFloat(device.sdk)).to.be.gte(10.8);
+    expect(device.sdk).to.be.eq('11');
+  });
+
+  it('Get android device based on filter with minSDK and maxSDK', () => {
+    const filterOptions = {
+      platform: 'android',
+      name: '',
+      busy: false,
+      offline: false,
+      minSDK: '10',
+      maxSDK: '10.0.1',
+    };
+    const device = getDevice(filterOptions);
+    expect(device.sdk).to.be.eq('10');
+  });
+
+  it('Get android device based on filter with maxSDK', () => {
+    const filterOptions = {
+      platform: 'android',
+      name: '',
+      busy: false,
+      offline: false,
+      maxSDK: '10.0.1',
+    };
+    const device = getDevice(filterOptions);
+    expect(device.sdk).to.be.eq('10');
   });
 
   it('Get ios simulator based on filter with minSDK', () => {
-    const filterOptions = { platform: 'ios', name: '', busy: false, offline: false, minSDK: 14.1 };
+    const filterOptions = { platform: 'ios', name: '', busy: false, offline: false, minSDK: '14.1.0' };
     const device = getDevice(filterOptions);
-    expect(parseFloat(device.sdk)).to.be.gte(14.1);
+    expect(device.sdk).to.be.eq('15.0');
+  });
+
+  it('Get ios simulator based on filter with maxSDK', () => {
+    const filterOptions = { platform: 'ios', name: '', busy: false, offline: false, maxSDK: '14.1.0' };
+    const device = getDevice(filterOptions);
+    expect(device.sdk).to.be.eq('14.0');
+  });
+
+  it('Get ios simulator based on filter with minSDK and maxSDK', () => {
+    const filterOptions = { platform: 'ios', name: '', busy: false, offline: false, minSDK: '14', maxSDK: '14.1.0' };
+    const device = getDevice(filterOptions);
+    expect(device.sdk).to.be.eq('14.0');
   });
 
   it('Get android device based on filter with platformVersion', () => {

--- a/test/unit/plugin.spec.js
+++ b/test/unit/plugin.spec.js
@@ -30,6 +30,7 @@ describe('Device filter tests', () => {
       deviceType: 'real',
       udid: undefined,
       minSDK: undefined,
+      maxSDK: undefined,
       busy: false,
       userBlocked: false,
     });
@@ -59,6 +60,7 @@ describe('Device filter tests', () => {
       deviceType: 'simulator',
       udid: undefined,
       minSDK: undefined,
+      maxSDK: undefined,
       busy: false,
       userBlocked: false,
     });
@@ -70,7 +72,7 @@ describe('Device filter tests', () => {
         platformName: 'iOS',
         'appium:app': '/Downloads/VodQA.app',
         'appium:iPhoneOnly': true,
-        'appium:minSDK': 10.2,
+        'appium:minSDK': '10.2.0',
       },
       firstMatch: [{}],
     };
@@ -82,7 +84,8 @@ describe('Device filter tests', () => {
       name: 'iPhone',
       deviceType: 'simulator',
       udid: undefined,
-      minSDK: 10.2,
+      minSDK: '10.2.0',
+      maxSDK: undefined,
       busy: false,
       userBlocked: false,
     });


### PR DESCRIPTION
This adds an `appium:maxSDK` capability. Combined with `appium:minSDK` you will be able to filter devices to a given range. 

Also, when working on https://github.com/AppiumTestDistribution/appium-device-farm/pull/576, I noticed that the `minSDK` filter only worked if the `device.sdk` could be cast to a float. For devices with semantic versioning, such as `16.1.2`, this filter didn't work. Using `semver`, you can now filter devices that have semantic versioning.