### PR TITLE
Fix bug in getDevice() query and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appium-device-farm",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "appium-device-farm",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "license": "ISC",
       "dependencies": {
         "@appium/base-plugin": "1.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-device-farm",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "An appium 2.0 plugin that manages and create driver session on available devices",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/data-service/device-service.ts
+++ b/src/data-service/device-service.ts
@@ -93,7 +93,8 @@ export function getDevice(filterOptions: IDeviceFilterOptions): IDevice {
 
   if (filterOptions.deviceType === 'simulator') {
     filter.state = 'Booted';
-    if (results.find(filter).data()[0] != undefined) {
+    const results_copy = results.copy();
+    if (results_copy.find(filter).data()[0] != undefined) {
       logger.info('Picking up booted simulator');
       return results.find(filter).data()[0];
     } else {


### PR DESCRIPTION
Follow-up PR to https://github.com/AppiumTestDistribution/appium-device-farm/pull/675 which fixes a bug in the `getDevice()` query and bumps version