### PR TITLE
Avoid crash when device is in unauthorized state.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appium-device-farm",
-  "version": "8.2.4",
+  "version": "8.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appium-device-farm",
-      "version": "8.2.4",
+      "version": "8.2.5",
       "license": "ISC",
       "dependencies": {
         "@appium/base-plugin": "^2.2.15",
@@ -5871,6 +5871,78 @@
         "appium": "^2.0.0-beta.40"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/base-driver": {
+      "version": "8.7.3",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@appium/support": "^2.61.1",
+        "@colors/colors": "1.5.0",
+        "@types/async-lock": "1.3.0",
+        "@types/bluebird": "3.5.37",
+        "@types/express": "4.17.14",
+        "@types/method-override": "0.0.32",
+        "@types/serve-favicon": "2.5.3",
+        "async-lock": "1.3.2",
+        "asyncbox": "2.9.2",
+        "axios": "0.27.2",
+        "bluebird": "3.7.2",
+        "body-parser": "1.20.1",
+        "es6-error": "4.1.1",
+        "express": "4.18.2",
+        "http-status-codes": "2.2.0",
+        "lodash": "4.17.21",
+        "lru-cache": "7.14.0",
+        "method-override": "3.0.0",
+        "morgan": "1.10.0",
+        "serve-favicon": "2.5.0",
+        "source-map-support": "0.5.21",
+        "type-fest": "3.1.0",
+        "validate.js": "0.13.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/base-driver/node_modules/axios": {
+      "version": "0.27.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/base-plugin": {
+      "version": "1.10.5",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@appium/support": "^2.61.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/docutils": {
+      "version": "0.0.13",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@appium/support": "^2.61.1",
+        "docdash": "1.2.0",
+        "jsdoc": "3.6.11",
+        "jsdoc-plugin-typescript": "2.2.0",
+        "source-map-support": "0.5.21",
+        "teen_process": "2.0.2"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=8"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/@appium/schema": {
       "version": "0.0.9",
       "dev": true,
@@ -6011,6 +6083,17 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/@babel/parser": {
+      "version": "7.20.0",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/@babel/runtime": {
       "version": "7.20.0",
       "dev": true,
@@ -6028,6 +6111,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@jimp/bmp": {
@@ -6459,6 +6552,77 @@
         "regenerator-runtime": "^0.13.3"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/@sidvind/better-ajv-errors": {
+      "version": "2.1.0",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/code-frame": "^7.16.0",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "4.11.8 - 8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@sidvind/better-ajv-errors/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@sidvind/better-ajv-errors/node_modules/chalk": {
+      "version": "4.1.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@sidvind/better-ajv-errors/node_modules/color-convert": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@sidvind/better-ajv-errors/node_modules/color-name": {
+      "version": "1.1.4",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@sidvind/better-ajv-errors/node_modules/supports-color": {
+      "version": "7.2.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "dev": true,
@@ -6489,6 +6653,16 @@
         "@types/glob": "*"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/@types/argparse": {
+      "version": "2.0.10",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@types/async-lock": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/@types/base64-stream": {
       "version": "1.0.2",
       "dev": true,
@@ -6496,6 +6670,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@types/bluebird": {
+      "version": "3.5.37",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -6546,6 +6725,11 @@
         "@types/range-parser": "*"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/@types/fancy-log": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/@types/find-root": {
       "version": "1.1.2",
       "dev": true,
@@ -6595,10 +6779,37 @@
         "@types/node": "*"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/@types/linkify-it": {
+      "version": "3.0.2",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/@types/lockfile": {
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@types/markdown-it": {
+      "version": "12.2.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@types/mdurl": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@types/method-override": {
+      "version": "0.0.32",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@types/mime": {
       "version": "3.0.1",
@@ -6683,6 +6894,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/@types/serve-favicon": {
+      "version": "2.5.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/@types/serve-static": {
       "version": "1.15.0",
       "dev": true,
@@ -6713,6 +6932,11 @@
     "node_modules/appium-uiautomator2-driver/node_modules/@types/uuid": {
       "version": "8.3.4",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@types/ws": {
@@ -6751,6 +6975,18 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/accepts": {
+      "version": "1.3.8",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/adbkit-apkreader": {
       "version": "3.2.0",
       "dev": true,
@@ -6770,6 +7006,37 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/ajv": {
+      "version": "8.11.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/ansi-regex": {
@@ -6994,6 +7261,16 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/argparse": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/array-flatten": {
+      "version": "1.1.1",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/async": {
       "version": "3.2.4",
       "dev": true,
@@ -7063,6 +7340,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/basic-auth": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/big-integer": {
       "version": "1.6.51",
       "dev": true,
@@ -7089,6 +7382,42 @@
     "node_modules/appium-uiautomator2-driver/node_modules/bmp-js": {
       "version": "0.1.0",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/body-parser": {
+      "version": "1.20.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/bplist-creator": {
@@ -7163,6 +7492,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/bytes": {
+      "version": "3.1.2",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/cacheable-lookup": {
       "version": "5.0.4",
       "dev": true,
@@ -7202,6 +7539,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/call-bind": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/catharsis": {
+      "version": "0.9.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/chalk": {
       "version": "2.4.2",
       "dev": true,
@@ -7234,6 +7594,36 @@
         "node": ">=4"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/cli-spinners": {
+      "version": "2.7.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/clone": {
+      "version": "1.0.4",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/clone-response": {
       "version": "1.0.3",
       "dev": true,
@@ -7243,6 +7633,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/color": {
+      "version": "3.2.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/color-convert": {
@@ -7258,12 +7657,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/color-string": {
+      "version": "1.9.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/color-support": {
       "version": "1.1.3",
       "dev": true,
       "license": "ISC",
       "bin": {
         "color-support": "bin.js"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/colorspace": {
+      "version": "1.1.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/combined-stream": {
@@ -7306,6 +7723,38 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/content-type": {
+      "version": "1.0.4",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/cookie": {
+      "version": "0.5.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/core-util-is": {
       "version": "1.0.3",
       "dev": true,
@@ -7332,6 +7781,36 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/cross-env": {
+      "version": "7.0.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/css-selector-parser": {
@@ -7364,12 +7843,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/defaults": {
+      "version": "1.0.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/defer-to-connect": {
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/define-properties": {
+      "version": "1.1.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/delayed-stream": {
@@ -7385,6 +7890,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/depd": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/destroy": {
+      "version": "1.2.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/docdash": {
+      "version": "1.2.0",
+      "extraneous": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/dom-walk": {
       "version": "0.1.2",
       "dev": true
@@ -7394,12 +7921,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/ee-first": {
+      "version": "1.1.1",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/enabled": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/end-of-stream": {
       "version": "1.4.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/entities": {
+      "version": "2.1.0",
+      "extraneous": true,
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/error-ex": {
@@ -7409,6 +7962,64 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/es-abstract": {
+      "version": "1.20.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
+        "get-intrinsic": "^1.1.3",
+        "get-symbol-description": "^1.0.0",
+        "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.7",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.2",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/es6-error": {
+      "version": "4.1.1",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/es6-mapify": {
       "version": "1.2.0",
@@ -7421,6 +8032,11 @@
         "@babel/runtime": "^7.0.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/escape-html": {
+      "version": "1.0.3",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "dev": true,
@@ -7429,9 +8045,71 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/etag": {
+      "version": "1.8.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/exif-parser": {
       "version": "0.1.12",
       "dev": true
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/express": {
+      "version": "4.18.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.1",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.5.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.11.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/fancy-log": {
       "version": "2.0.0",
@@ -7444,6 +8122,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/fd-slicer": {
       "version": "1.1.0",
       "dev": true,
@@ -7452,6 +8135,11 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/fecha": {
+      "version": "4.2.3",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/file-type": {
       "version": "9.0.0",
       "dev": true,
@@ -7459,6 +8147,36 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/finalhandler": {
+      "version": "1.2.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/find-up": {
       "version": "5.0.0",
@@ -7474,6 +8192,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/fn.name": {
+      "version": "1.1.0",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/follow-redirects": {
       "version": "1.15.2",
@@ -7505,6 +8228,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/forwarded": {
+      "version": "0.2.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/fresh": {
+      "version": "0.5.2",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/fs-constants": {
@@ -7553,6 +8292,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "extraneous": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/gauge": {
       "version": "4.0.4",
       "dev": true,
@@ -7597,6 +8361,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/get-intrinsic": {
+      "version": "1.1.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/get-stream": {
       "version": "6.0.1",
       "dev": true,
@@ -7606,6 +8383,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/gifwrap": {
@@ -7703,12 +8495,56 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/has-bigints": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/has-symbols": {
+      "version": "1.0.3",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/has-unicode": {
@@ -7726,6 +8562,26 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/http-errors": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/http2-wrapper": {
       "version": "1.0.3",
       "dev": true,
@@ -7736,6 +8592,17 @@
       },
       "engines": {
         "node": ">=10.19.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/ieee754": {
@@ -7792,6 +8659,19 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/internal-slot": {
+      "version": "1.0.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/io.appium.settings": {
       "version": "4.2.2",
       "dev": true,
@@ -7801,10 +8681,55 @@
         "npm": ">=8"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/is-arrayish": {
       "version": "0.2.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/is-bigint": {
+      "version": "1.0.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/is-callable": {
+      "version": "1.2.7",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/is-core-module": {
       "version": "2.11.0",
@@ -7817,10 +8742,43 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/is-date-object": {
+      "version": "1.0.5",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/is-function": {
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/is-interactive": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/is-negative-zero": {
+      "version": "2.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/is-number-like": {
       "version": "1.0.8",
@@ -7828,6 +8786,85 @@
       "license": "ISC",
       "dependencies": {
         "lodash.isfinite": "^3.3.2"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/is-number-object": {
+      "version": "1.0.7",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/is-regex": {
+      "version": "1.1.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/is-shared-array-buffer": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/is-stream": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/is-string": {
+      "version": "1.0.7",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/is-symbol": {
+      "version": "1.0.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/is-unicode-supported": {
@@ -7839,6 +8876,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/is-weakref": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/isexe": {
@@ -7867,6 +8915,69 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/js2xmlparser": {
+      "version": "4.0.2",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/jsdoc": {
+      "version": "3.6.11",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/parser": "^7.9.4",
+        "@types/markdown-it": "^12.2.3",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^3.0.0",
+        "markdown-it": "^12.3.2",
+        "markdown-it-anchor": "^8.4.1",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "taffydb": "2.6.2",
+        "underscore": "~1.13.2"
+      },
+      "bin": {
+        "jsdoc": "jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/jsdoc-plugin-typescript": {
+      "version": "2.2.0",
+      "extraneous": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "string.prototype.matchall": "^4.0.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/jsdoc/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/jsdoc/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/jsftp": {
       "version": "2.1.3",
@@ -7907,6 +9018,11 @@
       "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/keyv": {
       "version": "4.5.0",
       "dev": true,
@@ -7922,6 +9038,11 @@
       "dependencies": {
         "graceful-fs": "^4.1.9"
       }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/kuler": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/lazystream": {
       "version": "1.0.1",
@@ -7966,10 +9087,26 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/lilconfig": {
+      "version": "2.0.6",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/lines-and-columns": {
       "version": "1.2.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/linkify-it": {
+      "version": "3.0.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/load-bmfont": {
       "version": "1.4.1",
@@ -8114,6 +9251,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/logform": {
+      "version": "2.4.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/longjohn": {
+      "version": "0.2.12",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map-support": "0.3.2 - 1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.9.3"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/lowercase-keys": {
       "version": "2.0.0",
       "dev": true,
@@ -8128,6 +9288,94 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/markdown-it": {
+      "version": "12.3.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/markdown-it-anchor": {
+      "version": "8.6.5",
+      "extraneous": true,
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/marked": {
+      "version": "4.1.1",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/mdurl": {
+      "version": "1.0.1",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/media-typer": {
+      "version": "0.3.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/method-override": {
+      "version": "3.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "3.1.0",
+        "methods": "~1.1.2",
+        "parseurl": "~1.3.2",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/method-override/node_modules/debug": {
+      "version": "3.1.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/method-override/node_modules/ms": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/methods": {
+      "version": "1.1.2",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/mime": {
@@ -8158,6 +9406,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/mimic-response": {
@@ -8224,6 +9480,45 @@
         "node": "*"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/morgan": {
+      "version": "1.10.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/morgan/node_modules/debug": {
+      "version": "2.6.9",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/morgan/node_modules/ms": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/ms": {
       "version": "2.1.2",
       "dev": true,
@@ -8274,6 +9569,14 @@
       "license": "MIT",
       "bin": {
         "ncp": "bin/ncp"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/negotiator": {
+      "version": "0.6.3",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/normalize-package-data": {
@@ -8328,10 +9631,62 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/object-inspect": {
+      "version": "1.12.2",
+      "extraneous": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/object-keys": {
+      "version": "1.1.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/object.assign": {
+      "version": "4.1.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/omggif": {
       "version": "1.0.10",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/on-finished": {
+      "version": "2.4.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/on-headers": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/once": {
       "version": "1.4.0",
@@ -8341,10 +9696,110 @@
         "wrappy": "1"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/one-time": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/onetime": {
+      "version": "5.1.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/opencv-bindings": {
       "version": "4.5.5",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/ora": {
+      "version": "5.4.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/ora/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/ora/node_modules/color-convert": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/ora/node_modules/color-name": {
+      "version": "1.1.4",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/ora/node_modules/supports-color": {
+      "version": "7.2.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/p-cancelable": {
       "version": "2.1.1",
@@ -8380,6 +9835,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/package-changed": {
+      "version": "1.9.0",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "commander": "^6.2.0"
+      },
+      "bin": {
+        "package-changed": "bin/package-changed.js"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/package-changed/node_modules/commander": {
+      "version": "6.2.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/pako": {
@@ -8435,6 +9909,14 @@
         "node": ">=0.6.21"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/parseurl": {
+      "version": "1.3.3",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -8451,9 +9933,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/path-key": {
+      "version": "3.1.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/path-parse": {
       "version": "1.0.7",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/pend": {
@@ -8587,6 +10082,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/proxy-from-env": {
       "version": "1.1.0",
       "dev": true,
@@ -8601,6 +10108,28 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/punycode": {
+      "version": "2.1.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/qs": {
+      "version": "6.11.0",
+      "extraneous": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/quick-lru": {
       "version": "5.1.1",
       "dev": true,
@@ -8610,6 +10139,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/range-parser": {
+      "version": "1.2.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/raw-body": {
+      "version": "2.5.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/read-pkg": {
@@ -8679,6 +10230,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/requizzle": {
+      "version": "0.2.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/resolve": {
       "version": "1.22.1",
       "dev": true,
@@ -8717,6 +10300,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/rimraf": {
@@ -8771,6 +10366,32 @@
       ],
       "license": "MIT"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/safe-regex-test": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/safe-stable-stringify": {
+      "version": "2.4.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/sanitize-filename": {
       "version": "1.6.3",
       "dev": true,
@@ -8809,9 +10430,94 @@
         "node": ">=10"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/send": {
+      "version": "0.18.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/serve-favicon": {
+      "version": "2.5.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "ms": "2.1.1",
+        "parseurl": "~1.3.2",
+        "safe-buffer": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/serve-favicon/node_modules/ms": {
+      "version": "2.1.1",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/serve-favicon/node_modules/safe-buffer": {
+      "version": "5.1.1",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/serve-static": {
+      "version": "1.15.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.18.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/set-blocking": {
       "version": "2.0.0",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "extraneous": true,
       "license": "ISC"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/shared-preferences-builder": {
@@ -8831,6 +10537,25 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/shell-quote": {
       "version": "1.7.4",
       "dev": true,
@@ -8839,10 +10564,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/side-channel": {
+      "version": "1.0.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/signal-exit": {
       "version": "3.0.7",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/source-map": {
       "version": "0.6.1",
@@ -8889,6 +10640,22 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/stack-trace": {
+      "version": "0.0.10",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/statuses": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/stream-buffers": {
       "version": "2.2.0",
       "dev": true,
@@ -8914,6 +10681,50 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/string.prototype.matchall": {
+      "version": "4.0.7",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.1",
+        "side-channel": "^1.0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/string.prototype.trimend": {
+      "version": "1.0.5",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/string.prototype.trimstart": {
+      "version": "1.0.5",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/strip-ansi": {
       "version": "6.0.1",
       "dev": true,
@@ -8923,6 +10734,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/supports-color": {
@@ -8949,6 +10771,10 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/taffydb": {
+      "version": "2.6.2",
+      "extraneous": true
     },
     "node_modules/appium-uiautomator2-driver/node_modules/tar-stream": {
       "version": "2.2.0",
@@ -8998,6 +10824,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/text-hex": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/through": {
       "version": "2.3.8",
       "dev": true,
@@ -9015,6 +10846,19 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/toidentifier": {
+      "version": "1.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/triple-beam": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
@@ -9035,6 +10879,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/type-is": {
+      "version": "1.6.18",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -9050,12 +10906,52 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/uc.micro": {
+      "version": "1.0.6",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/unbox-primitive": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/underscore": {
+      "version": "1.13.6",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/unorm": {
       "version": "1.6.0",
       "dev": true,
       "license": "MIT or GPL-2.0",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/unpipe": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/uri-js": {
+      "version": "4.4.1",
+      "extraneous": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/utf7": {
@@ -9091,6 +10987,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/utils-merge": {
+      "version": "1.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/uuid": {
       "version": "8.3.2",
       "dev": true,
@@ -9108,6 +11012,27 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/validate.js": {
+      "version": "0.13.1",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/vary": {
+      "version": "1.1.2",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/wcwidth": {
+      "version": "1.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -9120,6 +11045,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/wide-align": {
@@ -9146,6 +11086,112 @@
     "node_modules/appium-uiautomator2-driver/node_modules/wide-align/node_modules/string-width": {
       "version": "4.2.3",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/winston": {
+      "version": "3.8.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.4.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/winston-transport": {
+      "version": "4.5.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 6.4.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -9225,6 +11271,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/xmlcreate": {
+      "version": "2.0.4",
+      "extraneous": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/xpath": {
       "version": "0.0.32",
       "dev": true,
@@ -9245,6 +11296,14 @@
       "version": "4.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/yaml": {
+      "version": "2.1.3",
+      "extraneous": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/yauzl": {
       "version": "2.10.0",
@@ -9389,6 +11448,35 @@
         "node": ">=12"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/@appium/base-plugin": {
+      "version": "1.10.5",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@appium/support": "^2.61.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/@appium/docutils": {
+      "version": "0.0.13",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@appium/support": "^2.61.1",
+        "docdash": "1.2.0",
+        "jsdoc": "3.6.11",
+        "jsdoc-plugin-typescript": "2.2.0",
+        "source-map-support": "0.5.21",
+        "teen_process": "2.0.2"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=8"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/@appium/schema": {
       "version": "0.0.9",
       "dev": true,
@@ -9529,6 +11617,17 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/@babel/parser": {
+      "version": "7.20.5",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/@babel/runtime": {
       "version": "7.20.6",
       "dev": true,
@@ -9546,6 +11645,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/@jimp/bmp": {
@@ -9977,6 +12086,77 @@
         "regenerator-runtime": "^0.13.3"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/@sidvind/better-ajv-errors": {
+      "version": "2.1.0",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/code-frame": "^7.16.0",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "4.11.8 - 8"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/@sidvind/better-ajv-errors/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/@sidvind/better-ajv-errors/node_modules/chalk": {
+      "version": "4.1.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/@sidvind/better-ajv-errors/node_modules/color-convert": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/@sidvind/better-ajv-errors/node_modules/color-name": {
+      "version": "1.1.4",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/@sidvind/better-ajv-errors/node_modules/supports-color": {
+      "version": "7.2.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "dev": true,
@@ -10006,6 +12186,11 @@
       "dependencies": {
         "@types/glob": "*"
       }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/@types/argparse": {
+      "version": "2.0.10",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/appium-xcuitest-driver/node_modules/@types/async-lock": {
       "version": "1.3.0",
@@ -10074,6 +12259,11 @@
         "@types/range-parser": "*"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/@types/fancy-log": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-xcuitest-driver/node_modules/@types/find-root": {
       "version": "1.1.2",
       "dev": true,
@@ -10122,9 +12312,28 @@
         "@types/node": "*"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/@types/linkify-it": {
+      "version": "3.0.2",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-xcuitest-driver/node_modules/@types/lockfile": {
       "version": "1.0.2",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/@types/markdown-it": {
+      "version": "12.2.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/@types/mdurl": {
+      "version": "1.0.2",
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/appium-xcuitest-driver/node_modules/@types/method-override": {
@@ -10258,6 +12467,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-xcuitest-driver/node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-xcuitest-driver/node_modules/@types/ws": {
       "version": "8.5.3",
       "dev": true,
@@ -10304,6 +12518,37 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/ajv": {
+      "version": "8.11.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/ansi-regex": {
@@ -10569,6 +12814,11 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/argparse": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "license": "Python-2.0"
     },
     "node_modules/appium-xcuitest-driver/node_modules/array-flatten": {
       "version": "1.1.1",
@@ -10855,6 +13105,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/catharsis": {
+      "version": "0.9.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/chalk": {
       "version": "2.4.2",
       "dev": true,
@@ -10887,6 +13148,36 @@
         "node": ">=4"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/cli-spinners": {
+      "version": "2.7.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/clone": {
+      "version": "1.0.4",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/clone-response": {
       "version": "1.0.3",
       "dev": true,
@@ -10896,6 +13187,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/color": {
+      "version": "3.2.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/color-convert": {
@@ -10911,12 +13211,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-xcuitest-driver/node_modules/color-string": {
+      "version": "1.9.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/color-support": {
       "version": "1.1.3",
       "dev": true,
       "license": "ISC",
       "bin": {
         "color-support": "bin.js"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/colorspace": {
+      "version": "1.1.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/combined-stream": {
@@ -11014,6 +13332,36 @@
         "node": ">= 10"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/cross-env": {
+      "version": "7.0.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/css-selector-parser": {
       "version": "1.4.1",
       "dev": true,
@@ -11044,12 +13392,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/defaults": {
+      "version": "1.0.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/defer-to-connect": {
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/define-properties": {
+      "version": "1.1.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/delayed-stream": {
@@ -11082,6 +13456,11 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/docdash": {
+      "version": "1.2.0",
+      "extraneous": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/appium-xcuitest-driver/node_modules/dom-walk": {
       "version": "0.1.2",
       "dev": true
@@ -11094,6 +13473,11 @@
     "node_modules/appium-xcuitest-driver/node_modules/ee-first": {
       "version": "1.1.1",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/enabled": {
+      "version": "2.0.0",
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/appium-xcuitest-driver/node_modules/encodeurl": {
@@ -11112,12 +13496,73 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/entities": {
+      "version": "2.1.0",
+      "extraneous": true,
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/error-ex": {
       "version": "1.3.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/es-abstract": {
+      "version": "1.20.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
+        "get-intrinsic": "^1.1.3",
+        "get-symbol-description": "^1.0.0",
+        "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.7",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.2",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/es6-error": {
@@ -11226,6 +13671,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-xcuitest-driver/node_modules/fd-slicer": {
       "version": "1.1.0",
       "dev": true,
@@ -11233,6 +13683,11 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/fecha": {
+      "version": "4.2.3",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/appium-xcuitest-driver/node_modules/file-type": {
       "version": "9.0.0",
@@ -11286,6 +13741,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/fn.name": {
+      "version": "1.1.0",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/appium-xcuitest-driver/node_modules/follow-redirects": {
       "version": "1.15.2",
@@ -11381,6 +13841,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-xcuitest-driver/node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "extraneous": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/gauge": {
       "version": "4.0.4",
       "dev": true,
@@ -11447,6 +13932,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/gifwrap": {
@@ -11544,6 +14044,14 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/has-bigints": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -11552,10 +14060,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/has-symbols": {
       "version": "1.0.3",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -11667,6 +14200,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/appium-xcuitest-driver/node_modules/internal-slot": {
+      "version": "1.0.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/ipaddr.js": {
       "version": "1.9.1",
       "dev": true,
@@ -11680,6 +14226,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-xcuitest-driver/node_modules/is-bigint": {
+      "version": "1.0.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/is-callable": {
+      "version": "1.2.7",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/is-core-module": {
       "version": "2.11.0",
       "dev": true,
@@ -11691,10 +14274,43 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/is-date-object": {
+      "version": "1.0.5",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/is-function": {
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/is-interactive": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/is-negative-zero": {
+      "version": "2.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/appium-xcuitest-driver/node_modules/is-number-like": {
       "version": "1.0.8",
@@ -11702,6 +14318,85 @@
       "license": "ISC",
       "dependencies": {
         "lodash.isfinite": "^3.3.2"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/is-number-object": {
+      "version": "1.0.7",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/is-regex": {
+      "version": "1.1.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/is-shared-array-buffer": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/is-stream": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/is-string": {
+      "version": "1.0.7",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/is-symbol": {
+      "version": "1.0.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/is-unicode-supported": {
@@ -11713,6 +14408,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/is-weakref": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/isexe": {
@@ -11742,10 +14448,73 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-xcuitest-driver/node_modules/js2xmlparser": {
+      "version": "4.0.2",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/js2xmlparser2": {
       "version": "0.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/jsdoc": {
+      "version": "3.6.11",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/parser": "^7.9.4",
+        "@types/markdown-it": "^12.2.3",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^3.0.0",
+        "markdown-it": "^12.3.2",
+        "markdown-it-anchor": "^8.4.1",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "taffydb": "2.6.2",
+        "underscore": "~1.13.2"
+      },
+      "bin": {
+        "jsdoc": "jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/jsdoc-plugin-typescript": {
+      "version": "2.2.0",
+      "extraneous": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "string.prototype.matchall": "^4.0.0"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/jsdoc/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/jsdoc/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/appium-xcuitest-driver/node_modules/jsftp": {
       "version": "2.1.3",
@@ -11786,6 +14555,11 @@
       "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
+    "node_modules/appium-xcuitest-driver/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-xcuitest-driver/node_modules/keyv": {
       "version": "4.5.2",
       "dev": true,
@@ -11801,6 +14575,11 @@
       "dependencies": {
         "graceful-fs": "^4.1.9"
       }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/kuler": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/appium-xcuitest-driver/node_modules/lazystream": {
       "version": "1.0.1",
@@ -11845,10 +14624,26 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/lilconfig": {
+      "version": "2.0.6",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/lines-and-columns": {
       "version": "1.2.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/linkify-it": {
+      "version": "3.0.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
     },
     "node_modules/appium-xcuitest-driver/node_modules/load-bmfont": {
       "version": "1.4.1",
@@ -11993,6 +14788,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/logform": {
+      "version": "2.4.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/longjohn": {
+      "version": "0.2.12",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map-support": "0.3.2 - 1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.9.3"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/lowercase-keys": {
       "version": "2.0.0",
       "dev": true,
@@ -12008,6 +14826,46 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/markdown-it": {
+      "version": "12.3.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/markdown-it-anchor": {
+      "version": "8.6.5",
+      "extraneous": true,
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/marked": {
+      "version": "4.2.3",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/mdurl": {
+      "version": "1.0.1",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/appium-xcuitest-driver/node_modules/media-typer": {
       "version": "0.3.0",
@@ -12085,6 +14943,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/mimic-response": {
@@ -12340,6 +15206,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/object-keys": {
+      "version": "1.1.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/object.assign": {
+      "version": "4.1.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/omggif": {
       "version": "1.0.10",
       "dev": true,
@@ -12372,10 +15263,110 @@
         "wrappy": "1"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/one-time": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/onetime": {
+      "version": "5.1.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/opencv-bindings": {
       "version": "4.5.5",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/ora": {
+      "version": "5.4.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/ora/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/ora/node_modules/color-convert": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/ora/node_modules/color-name": {
+      "version": "1.1.4",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/ora/node_modules/supports-color": {
+      "version": "7.2.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/appium-xcuitest-driver/node_modules/p-cancelable": {
       "version": "2.1.1",
@@ -12411,6 +15402,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/package-changed": {
+      "version": "1.9.0",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "commander": "^6.2.0"
+      },
+      "bin": {
+        "package-changed": "bin/package-changed.js"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/package-changed/node_modules/commander": {
+      "version": "6.2.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/pako": {
@@ -12488,6 +15498,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/path-key": {
+      "version": "3.1.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/path-parse": {
@@ -12628,6 +15646,14 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/punycode": {
+      "version": "2.1.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/qs": {
       "version": "6.11.0",
       "dev": true,
@@ -12742,6 +15768,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-xcuitest-driver/node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/requizzle": {
+      "version": "0.2.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/resolve": {
       "version": "1.22.1",
       "dev": true,
@@ -12780,6 +15838,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/rimraf": {
@@ -12833,6 +15903,27 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/safe-regex-test": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/safe-stable-stringify": {
+      "version": "2.4.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/appium-xcuitest-driver/node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -12967,6 +16058,25 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/appium-xcuitest-driver/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/shell-quote": {
       "version": "1.7.4",
       "dev": true,
@@ -12992,6 +16102,19 @@
       "version": "3.0.7",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/appium-xcuitest-driver/node_modules/source-map": {
       "version": "0.6.1",
@@ -13038,6 +16161,14 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/appium-xcuitest-driver/node_modules/stack-trace": {
+      "version": "0.0.10",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/statuses": {
       "version": "2.0.1",
       "dev": true,
@@ -13071,6 +16202,50 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/string.prototype.matchall": {
+      "version": "4.0.8",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/string.prototype.trimend": {
+      "version": "1.0.6",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/string.prototype.trimstart": {
+      "version": "1.0.6",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/strip-ansi": {
       "version": "6.0.1",
       "dev": true,
@@ -13080,6 +16255,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/supports-color": {
@@ -13106,6 +16292,10 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/taffydb": {
+      "version": "2.6.2",
+      "extraneous": true
     },
     "node_modules/appium-xcuitest-driver/node_modules/tar-stream": {
       "version": "2.2.0",
@@ -13155,6 +16345,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-xcuitest-driver/node_modules/text-hex": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-xcuitest-driver/node_modules/through": {
       "version": "2.3.8",
       "dev": true,
@@ -13180,6 +16375,11 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/triple-beam": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/appium-xcuitest-driver/node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
@@ -13227,6 +16427,30 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/uc.micro": {
+      "version": "1.0.6",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/unbox-primitive": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/underscore": {
+      "version": "1.13.6",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "node_modules/appium-xcuitest-driver/node_modules/unorm": {
       "version": "1.6.0",
       "dev": true,
@@ -13241,6 +16465,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/uri-js": {
+      "version": "4.4.1",
+      "extraneous": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/utf8-byte-length": {
@@ -13299,6 +16531,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/wcwidth": {
+      "version": "1.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -13311,6 +16551,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/wide-align": {
@@ -13337,6 +16592,112 @@
     "node_modules/appium-xcuitest-driver/node_modules/wide-align/node_modules/string-width": {
       "version": "4.2.3",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/winston": {
+      "version": "3.8.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.4.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/winston-transport": {
+      "version": "4.5.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 6.4.0"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -13416,6 +16777,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/xmlcreate": {
+      "version": "2.0.4",
+      "extraneous": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/appium-xcuitest-driver/node_modules/xtend": {
       "version": "4.0.2",
       "dev": true,
@@ -13428,6 +16794,14 @@
       "version": "4.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/yaml": {
+      "version": "2.1.3",
+      "extraneous": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/appium-xcuitest-driver/node_modules/yauzl": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-device-farm",
-  "version": "8.2.4",
+  "version": "8.2.5",
   "description": "An appium 2.0 plugin that manages and create driver session on available devices",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/device-managers/AndroidDeviceManager.ts
+++ b/src/device-managers/AndroidDeviceManager.ts
@@ -100,12 +100,12 @@ export default class AndroidDeviceManager implements IDeviceManager {
             log.info(`Android Device details for ${device.udid} not available. So querying now.`);
             // device may have changed the status since the last time we queried
             // we want to avoid device with offline or unauthorized status
-            //if (device.state === 'device') {
+            if (device.state === 'device') {
               const deviceInfo = await this.deviceInfo(device, adbInstance, cliArgs);
               deviceState.push(deviceInfo);
-            //} else {
-            //  log.info(`Device ${device.udid} is not in "device" state. So ignoring.`);
-            //}
+            } else {
+              log.info(`Device ${device.udid} is not in "device" state. So ignoring.`);
+            }
           }
         }
       });

--- a/src/device-managers/AndroidDeviceManager.ts
+++ b/src/device-managers/AndroidDeviceManager.ts
@@ -11,7 +11,6 @@ import { getUtilizationTime } from '../device-utils';
 import Adb from '@devicefarmer/adbkit';
 import { AbortController } from 'node-abort-controller';
 import asyncWait from 'async-wait-until';
-import logger from '../logger';
 import ip from 'ip';
 import NodeDevices from './NodeDevices';
 import { addNewDevice, removeDevice } from '../data-service/device-service';
@@ -78,6 +77,7 @@ export default class AndroidDeviceManager implements IDeviceManager {
   ) {
     await this.requireSdkRoot();
     const connectedDevices = await this.getConnectedDevices(cliArgs);
+    log.info(`fetchAndroidDevices: Connected devices: ${JSON.stringify(connectedDevices)}`);
     for (const [adbInstance, devices] of connectedDevices) {
       await asyncForEach(devices, async (device: IDevice) => {
         device.adbRemoteHost =
@@ -99,8 +99,14 @@ export default class AndroidDeviceManager implements IDeviceManager {
             });
           } else {
             log.info(`Android Device details for ${device.udid} not available. So querying now.`);
-            const deviceInfo = await this.deviceInfo(device, adbInstance, cliArgs);
-            deviceState.push(deviceInfo[0]);
+            // device may have changed the status since the last time we queried
+            // we want to avoid device with offline or unauthorized status
+            if (device.state === 'device') {
+              const deviceInfo = await this.deviceInfo(device, adbInstance, cliArgs);
+              deviceState.push(deviceInfo);
+            } else {
+              log.info(`Device ${device.udid} is not in "device" state. So ignoring.`);
+            }
           }
         }
       });
@@ -108,7 +114,7 @@ export default class AndroidDeviceManager implements IDeviceManager {
     return deviceState;
   }
 
-  private async deviceInfo(device: any, adbInstance: any, cliArgs: any) {
+  private async deviceInfo(device: any, adbInstance: any, cliArgs: any): Promise<IDevice> {
     const systemPort = await getFreePort();
     const totalUtilizationTimeMilliSec = await getUtilizationTime(device.udid);
     const [sdk, realDevice, name, chromeDriverPath] = await Promise.all([
@@ -125,8 +131,7 @@ export default class AndroidDeviceManager implements IDeviceManager {
     } else {
       host = `http://${ip.address()}:${cliArgs.port}`;
     }
-    return [
-      {
+    return {
         adbRemoteHost: adbInstance.adbHost,
         adbPort: adbInstance.adbPort,
         systemPort,
@@ -142,8 +147,8 @@ export default class AndroidDeviceManager implements IDeviceManager {
         totalUtilizationTimeMilliSec: totalUtilizationTimeMilliSec,
         sessionStartTime: 0,
         chromeDriverPath,
-      },
-    ] as Array<IDevice>;
+        userBlocked: false
+      };
   }
 
   private async getAdb(): Promise<any> {
@@ -186,54 +191,7 @@ export default class AndroidDeviceManager implements IDeviceManager {
     const originalADB = await this.getAdb();
     deviceList.set(originalADB, await originalADB.getConnectedDevices());
     const client = Adb.createClient();
-    const originalADBTracking = async () => {
-      try {
-        const tracker = await client.trackDevices();
-        tracker.on('add', async (device: any) => {
-          const clonedDevice = _.cloneDeep(device);
-          Object.assign(clonedDevice, { udid: clonedDevice['id'], state: clonedDevice['type'] });
-          if (device.state != 'offline') {
-            logger.info(`Device ${clonedDevice.udid} was plugged`);
-            this.initiateAbortControl(clonedDevice.udid);
-            await this.waitBootComplete(originalADB, clonedDevice.udid);
-            this.cancelAbort(clonedDevice.udid);
-            const trackedDevice: Array<IDevice> = await this.deviceInfo(
-              clonedDevice,
-              originalADB,
-              cliArgs
-            );
-            logger.info(`Adding device ${clonedDevice.udid} to list!`);
-            const hubExists = isHub(cliArgs);
-            if (hubExists) {
-              logger.info(`Updating Hub with device ${clonedDevice.udid}`);
-              const nodeDevices = new NodeDevices(cliArgs.plugin['device-farm'].hub);
-              await nodeDevices.postDevicesToHub(trackedDevice, 'add');
-            } else {
-              addNewDevice(trackedDevice);
-            }
-          }
-        });
-        tracker.on('remove', async (device) => {
-          const clonedDevice = _.cloneDeep(device);
-          Object.assign(clonedDevice, { udid: clonedDevice['id'], host: ip.address() });
-          const hubExists = isHub(cliArgs);
-          if (hubExists) {
-            logger.info(`Removing device from Hub with device ${clonedDevice.udid}`);
-            const nodeDevices = new NodeDevices(cliArgs.plugin['device-farm'].hub);
-            await nodeDevices.postDevicesToHub(clonedDevice, 'remove');
-          } else {
-            logger.warn(
-              `Removing device ${clonedDevice.udid} from list as the device was unplugged!`
-            );
-            removeDevice(clonedDevice);
-            this.abort(clonedDevice.udid);
-          }
-        });
-        tracker.on('end', () => console.log('Tracking stopped'));
-      } catch (err: any) {
-        console.error('Something went wrong:', err.stack);
-      }
-    };
+    const originalADBTracking = this.createLocalAdbTracker(client, originalADB, cliArgs);
     originalADBTracking();
     const adbRemote = cliArgs.plugin['device-farm'].adbRemote;
     if (adbRemote !== undefined && adbRemote.length > 0) {
@@ -250,47 +208,111 @@ export default class AndroidDeviceManager implements IDeviceManager {
           host: adbHost,
           port: adbPort,
         });
-        const remoteAdbTracking = async () => {
-          try {
-            const tracker = await remoteAdb.trackDevices();
-            tracker.on('add', async (device: any) => {
-              const clonedDevice = _.cloneDeep(device);
-              Object.assign(clonedDevice, {
-                udid: clonedDevice['id'],
-                state: clonedDevice['type'],
-              });
-              if (device.state != 'offline') {
-                logger.info(`Device ${clonedDevice.udid} was plugged in host ${adbHost}`);
-                this.initiateAbortControl(clonedDevice.udid);
-                await this.waitBootComplete(cloneAdb, clonedDevice.udid);
-                this.cancelAbort(clonedDevice.udid);
-                const trackedDevice: Array<IDevice> = await this.deviceInfo(
-                  clonedDevice,
-                  cloneAdb,
-                  cliArgs
-                );
-                logger.info(`Adding device ${clonedDevice.udid} to list!`);
-                addNewDevice(trackedDevice);
-              }
-            });
-            tracker.on('remove', async (device) => {
-              const clonedDevice = _.cloneDeep(device);
-              Object.assign(clonedDevice, { udid: clonedDevice['id'], host: adbHost });
-              logger.warn(
-                `Removing device ${clonedDevice.udid} from ${adbHost} list as the device was unplugged!`
-              );
-              removeDevice(clonedDevice);
-              this.abort(clonedDevice.udid);
-            });
-            tracker.on('end', () => console.log('Tracking stopped'));
-          } catch (err: any) {
-            console.error('Something went wrong:', err.stack);
-          }
-        };
+        const remoteAdbTracking = this.createRemoteAdbTracker(
+          remoteAdb,
+          originalADB,
+          adbHost,
+          cliArgs
+        );
         remoteAdbTracking();
       });
     }
     return deviceList;
+  }
+
+  private createLocalAdbTracker(adbClient: any, originalADB: any, cliArgs: any) {
+    const adbTracker = async () => {
+      try {
+        const tracker = await adbClient.trackDevices();
+        tracker.on('add', async (device: any) => {
+          const clonedDevice = _.cloneDeep(device);
+          Object.assign(clonedDevice, { udid: clonedDevice['id'], state: clonedDevice['type'] });
+          if (device.state != 'offline') {
+            log.info(`Device ${clonedDevice.udid} was plugged`);
+            this.initiateAbortControl(clonedDevice.udid);
+            await this.waitBootComplete(originalADB, clonedDevice.udid);
+            this.cancelAbort(clonedDevice.udid);
+            const trackedDevice: IDevice = await this.deviceInfo(
+              clonedDevice,
+              originalADB,
+              cliArgs
+            );
+            log.info(`Adding device ${clonedDevice.udid} to list!`);
+            const hubExists = isHub(cliArgs);
+            if (hubExists) {
+              log.info(`Updating Hub with device ${clonedDevice.udid}`);
+              const nodeDevices = new NodeDevices(cliArgs.plugin['device-farm'].hub);
+              await nodeDevices.postDevicesToHub(trackedDevice, 'add');
+            } else {
+              addNewDevice([trackedDevice]);
+            }
+          }
+        });
+        tracker.on('remove', async (device: any) => {
+          const clonedDevice = _.cloneDeep(device);
+          Object.assign(clonedDevice, { udid: clonedDevice['id'], host: ip.address() });
+          const hubExists = isHub(cliArgs);
+          if (hubExists) {
+            log.info(`Removing device from Hub with device ${clonedDevice.udid}`);
+            const nodeDevices = new NodeDevices(cliArgs.plugin['device-farm'].hub);
+            await nodeDevices.postDevicesToHub(clonedDevice, 'remove');
+          } else {
+            log.warn(
+              `Removing device ${clonedDevice.udid} from list as the device was unplugged!`
+            );
+            removeDevice(clonedDevice);
+            this.abort(clonedDevice.udid);
+          }
+        });
+        tracker.on('end', () => console.log('Tracking stopped'));
+      } catch (err: any) {
+        console.error('Something went wrong:', err.stack);
+      }
+    };
+
+    return adbTracker;
+  }
+
+  private createRemoteAdbTracker(adbClient: any, originalADB: any, adbHost: string, cliArgs: any) {
+    const adbTracking = async () => {
+      try {
+        const tracker = await adbClient.trackDevices();
+        tracker.on('add', async (device: any) => {
+          const clonedDevice = _.cloneDeep(device);
+          Object.assign(clonedDevice, {
+            udid: clonedDevice['id'],
+            state: clonedDevice['type'],
+          });
+          if (device.state != 'offline') {
+            log.info(`Device ${clonedDevice.udid} was plugged in host ${adbHost}`);
+            this.initiateAbortControl(clonedDevice.udid);
+            await this.waitBootComplete(originalADB, clonedDevice.udid);
+            this.cancelAbort(clonedDevice.udid);
+            const trackedDevice: IDevice = await this.deviceInfo(
+              clonedDevice,
+              originalADB,
+              cliArgs
+            );
+            log.info(`Adding device ${clonedDevice.udid} to list!`);
+            addNewDevice([trackedDevice]);
+          }
+        });
+        tracker.on('remove', async (device: any) => {
+          const clonedDevice = _.cloneDeep(device);
+          Object.assign(clonedDevice, { udid: clonedDevice['id'], host: adbHost });
+          log.warn(
+            `Removing device ${clonedDevice.udid} from ${adbHost} list as the device was unplugged!`
+          );
+          removeDevice(clonedDevice);
+          this.abort(clonedDevice.udid);
+        });
+        tracker.on('end', () => console.log('Tracking stopped'));
+      } catch (err: any) {
+        console.error('Something went wrong:', err.stack);
+      }
+    };
+
+    return adbTracking;
   }
 
   public async getChromeVersion(adbInstance: any, udid: string, cliArgs: any) {

--- a/src/device-managers/AndroidDeviceManager.ts
+++ b/src/device-managers/AndroidDeviceManager.ts
@@ -77,7 +77,6 @@ export default class AndroidDeviceManager implements IDeviceManager {
   ) {
     await this.requireSdkRoot();
     const connectedDevices = await this.getConnectedDevices(cliArgs);
-    log.info(`fetchAndroidDevices: Connected devices: ${JSON.stringify(connectedDevices)}`);
     for (const [adbInstance, devices] of connectedDevices) {
       await asyncForEach(devices, async (device: IDevice) => {
         device.adbRemoteHost =
@@ -101,12 +100,12 @@ export default class AndroidDeviceManager implements IDeviceManager {
             log.info(`Android Device details for ${device.udid} not available. So querying now.`);
             // device may have changed the status since the last time we queried
             // we want to avoid device with offline or unauthorized status
-            if (device.state === 'device') {
+            //if (device.state === 'device') {
               const deviceInfo = await this.deviceInfo(device, adbInstance, cliArgs);
               deviceState.push(deviceInfo);
-            } else {
-              log.info(`Device ${device.udid} is not in "device" state. So ignoring.`);
-            }
+            //} else {
+            //  log.info(`Device ${device.udid} is not in "device" state. So ignoring.`);
+            //}
           }
         }
       });

--- a/test/unit/AndroidDeviceManager.spec.js
+++ b/test/unit/AndroidDeviceManager.spec.js
@@ -87,6 +87,7 @@ describe('Android Device Manager', function () {
         sessionStartTime: 0,
         totalUtilizationTimeMilliSec: 0,
         chromeDriverPath: '/var/path/chromedriver',
+        userBlocked: false,
       },
       {
         busy: false,
@@ -104,6 +105,7 @@ describe('Android Device Manager', function () {
         sessionStartTime: 0,
         totalUtilizationTimeMilliSec: 0,
         chromeDriverPath: '/var/path/chromedriver',
+        userBlocked: false,
       },
     ]);
   });
@@ -148,6 +150,7 @@ describe('Android Device Manager', function () {
         sessionStartTime: 0,
         totalUtilizationTimeMilliSec: 0,
         chromeDriverPath: '/var/path/chromedriver',
+        userBlocked: false,
       },
     ]);
   });
@@ -192,6 +195,7 @@ describe('Android Device Manager', function () {
         sessionStartTime: 0,
         totalUtilizationTimeMilliSec: 0,
         chromeDriverPath: '/var/path/chromedriver',
+        userBlocked: false,
       },
     ]);
   });
@@ -243,6 +247,7 @@ describe('Android Device Manager', function () {
         sessionStartTime: 0,
         totalUtilizationTimeMilliSec: 0,
         chromeDriverPath: '/var/path/chromedriver',
+        userBlocked: false,
       },
     ]);
   });


### PR DESCRIPTION
`appium-device-farm` plugin will crash when device status is `unathorized`.
This PR prevents calling `deviceInfo` when device state is `unauthorized`.

It would be nice to have these `unauthorized` device to show up in the UI so someone can take an action. Maybe in another PR.