### PR TITLE
Fix : pCloudy vendor prefix

### DIFF
--- a/src/device-managers/cloud/CapabilityManager.ts
+++ b/src/device-managers/cloud/CapabilityManager.ts
@@ -15,8 +15,8 @@ export default class CapabilityManager {
       this.capabilities.alwaysMatch[`appium:${key}`] = val;
     });
     if (this.freeDevice.cloud.toLowerCase() === Cloud.PCLOUDY) {
-      this.capabilities.alwaysMatch['pCloudy_ApiKey'] = process.env.CLOUD_KEY;
-      this.capabilities.alwaysMatch['pCloudy_Username'] = process.env.CLOUD_USERNAME;
+      this.capabilities.alwaysMatch['appium:pCloudy_ApiKey'] = process.env.CLOUD_KEY;
+      this.capabilities.alwaysMatch['appium:pCloudy_Username'] = process.env.CLOUD_USERNAME;
     }
     return this.capabilities;
   }


### PR DESCRIPTION
All non-standard capabilities should have a vendor prefix. The following capabilities did not have one: pCloudy_ApiKey,pCloudy_Username


[HTTP] --> POST /session
[HTTP] {"capabilities":{"firstMatch":[{}],"alwaysMatch":{"appium:adbExecTimeout":140000,"appium:appActivity":"com.games24x7.coregame.common.deeplink.DeepLinkActivity","appium:appPackage":"com.my11circle.android.stage","appium:autoGrantPermissions":true,"appium:automationName":"UiAutomator2","appium:deviceName":"android","appium:noReset":false,"appium:noSign":true,"appium:uiautomator2ServerInstallTimeout":120000,"platformName":"ANDROID","appium:clearDeviceLogsOnStart":true,"appium:nativeWebScreenshot":true,"appium:mjpegServerPort":52672,"appium:pCloudy_DeviceVersion":"8.0.0","appium:pCloudy_DeviceManufacturer":"demo","appium:udid":"HNB3N7D5","appium:platform":"android","appium:pCloudy_DeviceFullName":"HNB3N7D5","pCloudy_ApiKey":"anil","pCloudy_Username":"anil"}}}
[debug] [AppiumDriver@370f] Calling AppiumDriver.createSession() with args: [null,null,{"firstMatch":[{}],"alwaysMatch":{"appium:adbExecTimeout":140000,"appium:appActivity":"com.games24x7.coregame.common.deeplink.DeepLinkActivity","appium:appPackage":"com.my11circle.android.stage","appium:autoGrantPermissions":true,"appium:automationName":"UiAutomator2","appium:deviceName":"android","appium:noReset":false,"appium:noSign":true,"appium:uiautomator2ServerInstallTimeout":120000,"platformName":"ANDROID","appium:clearDeviceLogsOnStart":true,"appium:nativeWebScreenshot":true,"appium:mjpegServerPort":52672,"appium:pCloudy_DeviceVersion":"8.0.0","appium:pCloudy_DeviceManufacturer":"demo","appium:udid":"HNB3N7D5","appium:platform":"android","appium:pCloudy_DeviceFullName":"HNB3N7D5","pCloudy_ApiKey":"anil","pCloudy_Username":"anil"}}]
[AppiumDriver@370f] Plugins which can handle cmd 'createSession': appium-dashboard,device-farm
[AppiumDriver@370f] Plugin device-farm is now handling cmd 'createSession'
{
  'appium:adbExecTimeout': 140000,
  'appium:appActivity': 'xxxx',
  'appium:appPackage': 'xxxx',
  'appium:autoGrantPermissions': true,
  'appium:automationName': 'UiAutomator2',
  'appium:deviceName': 'android',
  'appium:noReset': false,
  'appium:noSign': true,
  'appium:uiautomator2ServerInstallTimeout': 120000,
  platformName: 'ANDROID',
  'appium:clearDeviceLogsOnStart': true,
  'appium:nativeWebScreenshot': true,
  'appium:mjpegServerPort': 52672,
  'appium:pCloudy_DeviceVersion': '8.0.0',
  'appium:pCloudy_DeviceManufacturer': 'demo',
  'appium:udid': 'HNB3N7D5',
  'appium:platform': 'android',
  'appium:pCloudy_DeviceFullName': 'HNB3N7D5',
  pCloudy_ApiKey: 'anil',
  pCloudy_Username: 'anil'
}
[device-farm] {"platform":"android","name":"","udid":"HNB3N7D5","busy":false,"userBlocked":false}
[device-farm] Waiting for free device
[device-farm] 📱 Device found: {"adbPort":5037,"systemPort":61323,"sdk":"7.1.1","realDevice":true,"name":"Lenovo K8 Plus","busy":false,"state":"device","udid":"HNB3N7D5","platform":"android","deviceType":"real","host":"http://192.168.100.39:4723","totalUtilizationTimeMilliSec":6598002,"sessionStartTime":0,"userBlocked":false,"offline":false,"meta":{"revision":37,"created":1697189887955,"version":0,"updated":1697190681004},"$loki":1,"dashboard_link":"http://devicelab4.games24x7.com:4723/dashboard?device_udid=HNB3N7D5&start_time=2023-10-13T09:38:04.396Z","total_session_count":2}
[device-farm] 📱 Blocking device HNB3N7D5 for new session
[AppiumDriver@370f] Plugin appium-dashboard is now handling cmd 'createSession'
[AppiumDriver@370f] Executing default handling behavior for command 'createSession'
[debug] [AppiumDriver@370f] Event 'newSessionRequested' logged at 1697190794084 (15:23:14 GMT+0530 (India Standard Time))
[Appium] Could not parse W3C capabilities: All non-standard capabilities should have a vendor prefix. The following capabilities did not have one: pCloudy_ApiKey,pCloudy_Username
[HTTP] --> POST /session
[HTTP] {"capabilities":{"firstMatch":[{}],"alwaysMatch":{"appium:adbExecTimeout":140000,"appium:appActivity":"com.games24x7.coregame.common.deeplink.DeepLinkActivity","appium:appPackage":"com.my11circle.android.stage","appium:autoGrantPermissions":true,"appium:automationName":"UiAutomator2","appium:deviceName":"android","appium:noReset":false,"appium:noSign":true,"appium:uiautomator2ServerInstallTimeout":120000,"platformName":"ANDROID","appium:clearDeviceLogsOnStart":true,"appium:nativeWebScreenshot":true,"appium:mjpegServerPort":52671,"appium:pCloudy_DeviceVersion":"8.0.0","appium:pCloudy_DeviceManufacturer":"demo","appium:udid":"MJ9HLJCUQCQWINZP","appium:platform":"android","appium:pCloudy_DeviceFullName":"MJ9HLJCUQCQWINZP","pCloudy_ApiKey":"anil","pCloudy_Username":"anil"}}}
[debug] [AppiumDriver@370f] Calling AppiumDriver.createSession() with args: [null,null,{"firstMatch":[{}],"alwaysMatch":{"appium:adbExecTimeout":140000,"appium:appActivity":"com.games24x7.coregame.common.deeplink.DeepLinkActivity","appium:appPackage":"com.my11circle.android.stage","appium:autoGrantPermissions":true,"appium:automationName":"UiAutomator2","appium:deviceName":"android","appium:noReset":false,"appium:noSign":true,"appium:uiautomator2ServerInstallTimeout":120000,"platformName":"ANDROID","appium:clearDeviceLogsOnStart":true,"appium:nativeWebScreenshot":true,"appium:mjpegServerPort":52671,"appium:pCloudy_DeviceVersion":"8.0.0","appium:pCloudy_DeviceManufacturer":"demo","appium:udid":"MJ9HLJCUQCQWINZP","appium:platform":"android","appium:pCloudy_DeviceFullName":"MJ9HLJCUQCQWINZP","pCloudy_ApiKey":"anil","pCloudy_Username":"anil"}}]
[AppiumDriver@370f] Plugins which can handle cmd 'createSession': appium-dashboard,device-farm
[AppiumDriver@370f] Plugin device-farm is now handling cmd 'createSession'
{
  'appium:adbExecTimeout': 140000,
  'appium:appActivity': 'com.games24x7.coregame.common.deeplink.DeepLinkActivity',
  'appium:appPackage': 'com.my11circle.android.stage',
  'appium:autoGrantPermissions': true,
  'appium:automationName': 'UiAutomator2',
  'appium:deviceName': 'android',
  'appium:noReset': false,
  'appium:noSign': true,
  'appium:uiautomator2ServerInstallTimeout': 120000,
  platformName: 'ANDROID',
  'appium:clearDeviceLogsOnStart': true,
  'appium:nativeWebScreenshot': true,
  'appium:mjpegServerPort': 52671,
  'appium:pCloudy_DeviceVersion': '8.0.0',
  'appium:pCloudy_DeviceManufacturer': 'demo',
  'appium:udid': 'MJ9HLJCUQCQWINZP',
  'appium:platform': 'android',
  'appium:pCloudy_DeviceFullName': 'MJ9HLJCUQCQWINZP',
  pCloudy_ApiKey: 'anil',
  pCloudy_Username: 'anil'
}
[device-farm] {"platform":"android","name":"","udid":"MJ9HLJCUQCQWINZP","busy":false,"userBlocked":false}
[device-farm] Waiting for free device
[device-farm] 📱 Device found: {"adbPort":5037,"systemPort":61334,"sdk":"10","realDevice":true,"name":"Android Bluedroid","busy":false,"state":"device","udid":"MJ9HLJCUQCQWINZP","platform":"android","deviceType":"real","host":"http://192.168.100.39:4723","totalUtilizationTimeMilliSec":3005253,"sessionStartTime":0,"userBlocked":false,"offline":false,"meta":{"revision":24,"created":1697189887955,"version":0,"updated":1697190669059},"$loki":2,"dashboard_link":"http://devicelab4.games24x7.com:4723/dashboard?device_udid=MJ9HLJCUQCQWINZP&start_time=2023-10-13T09:38:04.396Z","total_session_count":2}
[device-farm] 📱 Blocking device MJ9HLJCUQCQWINZP for new session
[AppiumDriver@370f] Plugin appium-dashboard is now handling cmd 'createSession'
[AppiumDriver@370f] Executing default handling behavior for command 'createSession'
[debug] [AppiumDriver@370f] Event 'newSessionRequested' logged at 1697190794089 (15:23:14 GMT+0530 (India Standard Time))
[Appium] Could not parse W3C capabilities: All non-standard capabilities should have a vendor prefix. The following capabilities did not have one: pCloudy_ApiKey,pCloudy_Username
[debug] [AppiumDriver@370f] Event 'newSessionStarted' logged at 1697190794090 (15:23:14 GMT+0530 (India Standard Time))
[debug] [AppiumDriver@370f] Event 'newSessionStarted' logged at 1697190794090 (15:23:14 GMT+0530 (India Standard Time))
[device-farm] 📱 Device UDID HNB3N7D5 unblocked. Reason: Session failed to create
[device-farm] 📱 Device UDID MJ9HLJCUQCQWINZP unblocked. Reason: Session failed to create
[debug] [AppiumDriver@370f] Encountered internal error running command: InvalidArgumentError: All non-standard capabilities should have a vendor prefix. The following capabilities did not have one: pCloudy_ApiKey,pCloudy_Username
[debug] [AppiumDriver@370f]     at parseCaps (/usr/local/lib/node_modules/appium/node_modules/@appium/base-driver/lib/basedriver/capabilities.js:252:11)
[debug] [AppiumDriver@370f]     at processCapabilities (/usr/local/lib/node_modules/appium/node_modules/@appium/base-driver/lib/basedriver/capabilities.js:332:43)
[debug] [AppiumDriver@370f]     at parseCapsForInnerDriver (/usr/local/lib/node_modules/appium/lib/utils.js:151:40)
[debug] [AppiumDriver@370f]     at AppiumDriver.createSession (/usr/local/lib/node_modules/appium/lib/appium.js:257:49)
[debug] [AppiumDriver@370f]     at commandExecutor (/usr/local/lib/node_modules/appium/node_modules/@appium/base-driver/lib/basedriver/driver.ts:107:18)
[debug] [AppiumDriver@370f]     at AppiumDriver.executeCommand (/usr/local/lib/node_modules/appium/node_modules/@appium/base-driver/lib/basedriver/driver.ts:124:15)
[debug] [AppiumDriver@370f]     at processTicksAndRejections (node:internal/process/task_queues:95:5)
[debug] [AppiumDriver@370f]     at defaultBehavior (/usr/local/lib/node_modules/appium/lib/appium.js:696:16)
[debug] [AppiumDriver@370f] Encountered internal error running command: InvalidArgumentError: All non-standard capabilities should have a vendor prefix. The following capabilities did not have one: pCloudy_ApiKey,pCloudy_Username
[debug] [AppiumDriver@370f]     at parseCaps (/usr/local/lib/node_modules/appium/node_modules/@appium/base-driver/lib/basedriver/capabilities.js:252:11)
[debug] [AppiumDriver@370f]     at processCapabilities (/usr/local/lib/node_modules/appium/node_modules/@appium/base-driver/lib/basedriver/capabilities.js:332:43)
[debug] [AppiumDriver@370f]     at parseCapsForInnerDriver (/usr/local/lib/node_modules/appium/lib/utils.js:151:40)
[debug] [AppiumDriver@370f]     at AppiumDriver.createSession (/usr/local/lib/node_modules/appium/lib/appium.js:257:49)
[debug] [AppiumDriver@370f]     at commandExecutor (/usr/local/lib/node_modules/appium/node_modules/@appium/base-driver/lib/basedriver/driver.ts:107:18)
[debug] [AppiumDriver@370f]     at AppiumDriver.executeCommand (/usr/local/lib/node_modules/appium/node_modules/@appium/base-driver/lib/basedriver/driver.ts:124:15)
[debug] [AppiumDriver@370f]     at processTicksAndRejections (node:internal/process/task_queues:95:5)
[debug] [AppiumDriver@370f]     at defaultBehavior (/usr/local/lib/node_modules/appium/lib/appium.js:696:16)
[HTTP] <-- POST /session 400 48 ms - 1224
[HTTP] 
[HTTP] <-- POST /session 400 34 ms - 1224
[HTTP] 
[HTTP] --> GET /device-farm/api/devices
[HTTP] {}
[HTTP] --> GET /dashboard/api/sessions?start_time=2023-10-13T09:38:04.396Z
[HTTP] {}
[HTTP] <-- GET /dashboard/api/sessions?start_time=2023-10-13T09:38:04.396Z 200 11 ms - 10658
[HTTP] 
[HTTP] <-- GET /device-farm/api/devices 200 19 ms - 1123
[HTTP] 
