### PR TITLE
Prevent spawning multiple ios tracker process

### DIFF
--- a/src/device-managers/IOSDeviceManager.ts
+++ b/src/device-managers/IOSDeviceManager.ts
@@ -136,7 +136,7 @@ export default class IOSDeviceManager implements IDeviceManager {
         deviceState.push(deviceInfo);
       }
     });
-    const goIosTracker = new GoIosTracker();
+    const goIosTracker = GoIosTracker.getInstance();
     await goIosTracker.start();
     goIosTracker.on('device-connected', async (message) => {
       const deviceAttached = [await this.getDeviceInfo(message.id, cliArgs)];

--- a/src/device-managers/iOSTracker.ts
+++ b/src/device-managers/iOSTracker.ts
@@ -4,9 +4,22 @@ import { SubProcess } from 'teen_process';
 import { cachePath } from '../helpers';
 import log from '../logger';
 export class GoIosTracker extends EventEmitter {
+  private static instance: GoIosTracker;
   private deviceMap: Map<number, string> = new Map();
   private process!: SubProcess;
   private started = true;
+
+  private constructor() {
+    super();
+  }
+
+  public static getInstance(): GoIosTracker {
+    if (!GoIosTracker.instance) {
+      GoIosTracker.instance = new GoIosTracker();
+    }
+
+    return GoIosTracker.instance;
+  }
 
   async start() {
     if (!_.isNil(this.process) && this.process.isRunning) {

--- a/src/device-utils.ts
+++ b/src/device-utils.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-prototype-builtins */
-import { isMac, checkIfPathIsAbsolute, hasHubArgument, cachePath } from './helpers';
+import { isMac, checkIfPathIsAbsolute, isDeviceFarmRunning, cachePath } from './helpers';
 import { ServerCLI } from './types/CLIArgs';
 import { Platform } from './types/Platform';
 import { androidCapabilities, iOSCapabilities } from './CapabilityManager';
@@ -48,6 +48,7 @@ const customCapability = {
 let timer: any;
 let cronTimerToReleaseBlockedDevices: any;
 let cronTimerToUpdateDevices: any;
+let cronTimerToUpdateNodeDevices: any;
 
 export const getDeviceTypeFromApp = (app: string) => {
   /* If the test is targeting safarim, then app capability will be empty */
@@ -261,7 +262,12 @@ export async function updateDeviceList(hubArgument?: string) {
   const devices: Array<IDevice> = await getDeviceManager().getDevices(getAllDevices());
   if (hubArgument) {
     const nodeDevices = new NodeDevices(hubArgument);
-    await nodeDevices.postDevicesToHub(devices, 'add');
+    try {
+      await nodeDevices.postDevicesToHub(devices, 'add');
+    } catch (error) {
+      log.error(`Cannot send device list update. Reason: ${error}`)
+    }
+    
   }
   addNewDevice(devices);
 
@@ -294,7 +300,7 @@ export async function checkNodeServerAvailability() {
     const iterableSet = [...devices];
     const nodeConnections = iterableSet.map(async (device: any) => {
       nodeChecked.push(device.host);
-      await DevicePlugin.waitForRemoteHubServerToBeRunning(device.host);
+      await DevicePlugin.waitForRemoteDeviceFarmToBeRunning(device.host);
       return device.host;
     });
 
@@ -360,8 +366,27 @@ export async function cronUpdateDeviceList(hubArgument: string) {
     clearInterval(cronTimerToUpdateDevices);
   }
   log.info(`This node will send device list update to the hub (${hubArgument}) every ${intervalMs} ms`)
-  await updateDeviceList(hubArgument);
+  
   cronTimerToUpdateDevices = setInterval(async () => {
-    await updateDeviceList(hubArgument);
+    if (await isDeviceFarmRunning(hubArgument)) {
+      await updateDeviceList(hubArgument);
+    } else {
+      log.warn(`Not sending device update since hub ${hubArgument} is not running`)
+    }
+  }, intervalMs);
+}
+
+/**
+ * Remove devices from unavailable nodes
+ * @param hubArgument host
+ */
+export async function cronRefreshNodeDevices() {
+  const intervalMs = 1000 * 60 * 5 // 5 minutes
+  if (cronTimerToUpdateNodeDevices) {
+    clearInterval(cronTimerToUpdateNodeDevices);
+  }
+  
+  cronTimerToUpdateNodeDevices = setInterval(async () => {
+    await checkNodeServerAvailability();
   }, intervalMs);
 }

--- a/src/device-utils.ts
+++ b/src/device-utils.ts
@@ -385,8 +385,10 @@ export async function cronRefreshNodeDevices() {
   if (cronTimerToUpdateNodeDevices) {
     clearInterval(cronTimerToUpdateNodeDevices);
   }
+  log.info(`Plugin will check for stale device-farm nodes every ${intervalMs} ms`)
   
   cronTimerToUpdateNodeDevices = setInterval(async () => {
+    log.info("Scanning for stale nodes.")
     await checkNodeServerAvailability();
   }, intervalMs);
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -10,6 +10,7 @@ import Cloud from './enums/Cloud';
 import normalizeUrl from 'normalize-url';
 import ora from 'ora';
 import asyncWait from 'async-wait-until';
+import axios from 'axios';
 
 const APPIUM_VENDOR_PREFIX = 'appium:';
 export async function asyncForEach(
@@ -166,4 +167,22 @@ export function stripAppiumPrefixes(caps: any) {
     );
   }
   return strippedCaps;
+}
+
+export async function isDeviceFarmRunning(host: string): Promise<boolean> {
+  try {
+    const result = await axios({
+      method: 'get',
+      url: `${host}/device-farm`,
+      timeout: 30000,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    return result.status == 200
+  } catch (error: any) {
+    return false
+  }
+  
 }


### PR DESCRIPTION
Recent PR triggered a regression where ios tracker process is spawned multiple times. This it turn depletes system resources. This PR fix it by making ios tracker as a singleton.

This PR also brings:
- Regular device list update to hub only happen when hub is online.
- Regularly check for stale nodes every 5 minutes. This is to anticipate when node is down and stale device info were displayed on device-farm UI.