### PR TITLE
fix: gracefully handle adb timeout

### DIFF
--- a/src/device-managers/AndroidDeviceManager.ts
+++ b/src/device-managers/AndroidDeviceManager.ts
@@ -139,13 +139,19 @@ export default class AndroidDeviceManager implements IDeviceManager {
       return undefined;
     }
 
-    // check we got all the info we need
-    if (deviceInfo.some((info) => _.isNil(info))) {
-      log.info(`Cannot get device info for ${device.udid}. Skipping`);
+    const [sdk, realDevice, name, chromeDriverPath] = deviceInfo;
+
+    // if cliArgs contains skipChromeDownload, then chromeDriverPath will be undefined
+    if (!cliArgs.plugin['device-farm'].skipChromeDownload && chromeDriverPath === undefined) {
+      log.info(`Cannot get chromeDriverPath for ${device.udid}. Skipping`);
       return undefined;
     }
 
-    const [sdk, realDevice, name, chromeDriverPath] = deviceInfo;
+    // Except for chromeDriverPath, all other info is mandatory
+    if (_.isNil(sdk) || _.isNil(realDevice) || _.isNil(name)) {
+      log.info(`Cannot get device info for ${device.udid}. Skipping`);
+      return undefined;
+    }
 
     let host;
     if (adbInstance.adbHost != null) {

--- a/test/unit/device-service.spec.js
+++ b/test/unit/device-service.spec.js
@@ -112,7 +112,7 @@ describe('Get device', () => {
   });
 
 
-  it.only('Get iOS device based on filter real device', () => {
+  it('Get iOS device based on filter real device', () => {
     const filterOptions = {"platform":"ios","name":"","deviceType":"real","busy":false,"userBlocked":false};
     const device = getDevice(filterOptions);
     console.log(device)
@@ -145,7 +145,7 @@ describe('Get device', () => {
   it('Get ios simulator based on filter with minSDK', () => {
     const filterOptions = { platform: 'ios', name: '', busy: false, offline: false, minSDK: '14.1.0' };
     const device = getDevice(filterOptions);
-    expect(device.sdk).to.be.eq('15.0');
+    expect(device.sdk).to.be.eq('15');
   });
 
   it('Get ios simulator based on filter with maxSDK', () => {


### PR DESCRIPTION
In my device-farm, the hub/nodes sometimes crash with the following log:

```
[ADB] Running '/Users/ci/Library/Android SDK/platform-tools/adb -P 5037 -s abcdef shell getprop init.svc.bootanim'
uncaughtException: Timed out after waiting for 60000 ms
Error: Timed out after waiting for 60000 ms
    at /Users/ci/.appium/node_modules/appium-device-farm/node_modules/async-wait-until/dist/index.js:1:1034
    at runNextTicks (node:internal/process/task_queues:60:5)
    at listOnTimeout (node:internal/timers:540:9)
    at processTimers (node:internal/timers:514:7)
uncaughtException: Timed out after waiting for 60000 ms
```

This PR adds typing for `getDeviceProperty` and adds graceful handling for other methods when `getDeviceProperty` returns `undefined`.