### PR TITLE
Use semver.satisfies() to filter the platformVersion by multiples inputs

### DIFF
--- a/src/data-service/device-service.ts
+++ b/src/data-service/device-service.ts
@@ -128,10 +128,10 @@ export async function getDevices(filterOptions: IDeviceFilterOptions): Promise<I
             const coercedSDK = semver.coerce(obj.sdk);
             // log.debug(`coerced obj SDK: ${coercedSDK}`);
             if (coercedSDK && coercedPlatformVersion) {
-              /*log.debug(
-                `coerced obj SDK: ${coercedSDK} == coercedPlatformVersion: ${coercedPlatformVersion}`,
-              );*/
-              return semver.eq(coercedSDK, coercedPlatformVersion);
+              log.debug(
+                `coerced obj SDK: ${coercedSDK} == filterOptions.platformVersion: ${filterOptions.platformVersion}`,
+              );
+              return semver.satisfies(coercedSDK, filterOptions.platformVersion as string);
             }
             return false;
           });

--- a/test/unit/device-service.spec.ts
+++ b/test/unit/device-service.spec.ts
@@ -220,6 +220,30 @@ describe('Get device', () => {
     expect(device?.sdk).to.be.eql('10');
   });
 
+  it('Get android device based on filter with platformVersion wildcard', async () => {
+    const filterOptions = {
+      platform: 'android',
+      name: '',
+      busy: false,
+      offline: false,
+      platformVersion: '10.*',
+    } as unknown as IDeviceFilterOptions;
+    const device = await getDevice(filterOptions);
+    expect(device?.sdk).to.be.eql('10');
+  });
+
+  it('Get android simulator based on filter with platformVersion range', async () => {
+    const filterOptions = {
+      platform: 'android',
+      name: '',
+      busy: false,
+      offline: false,
+      platformVersion: '10.0.1 - 14.1.0'
+    } as unknown as IDeviceFilterOptions;
+    const device = await getDevice(filterOptions);
+    expect(device?.sdk).to.be.eql('11');
+  });
+
   it('Get ios simulator based on filter with platform', async () => {
     const filterOptions = {
       platform: 'ios',
@@ -238,6 +262,30 @@ describe('Get device', () => {
       busy: false,
       offline: false,
       platformVersion: '14.0',
+    } as unknown as IDeviceFilterOptions;
+    const device = await getDevice(filterOptions);
+    expect(device?.sdk).to.be.eql('14.0');
+  });
+
+  it('Get ios simulator based on filter with platformVersion wildcard', async () => {
+    const filterOptions = {
+      platform: 'ios',
+      name: '',
+      busy: false,
+      offline: false,
+      platformVersion: '15.*',
+    } as unknown as IDeviceFilterOptions;
+    const device = await getDevice(filterOptions);
+    expect(device?.sdk).to.be.eql('15');
+  });
+
+  it('Get ios simulator based on filter with platformVersion range', async () => {
+    const filterOptions = {
+      platform: 'ios',
+      name: '',
+      busy: false,
+      offline: false,
+      platformVersion: '14 - 14.1.0',
     } as unknown as IDeviceFilterOptions;
     const device = await getDevice(filterOptions);
     expect(device?.sdk).to.be.eql('14.0');


### PR DESCRIPTION
Hello,


### Description
Currently we can only filter and find a device by a fixed version or with the `minSDK` and `maxSDK`

The method `semver.satisfies()` allow us to find a device by multiples filters:
- Wildcard: `16.*`
- Min and Max: `15.0 - 16.0`
- Min: `>=15.0`
- Max `<=15.0`
- etc..


### What I did
- I replaced the strict equal versions (`eq` => `satisfies`)
- Added 2 iOS and 2 Android tests to match the new filters.

