### PR TITLE
feat: headspin: consider -pa flag

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -39,7 +39,7 @@ Refer on LambdaTest config [here](https://github.com/AppiumTestDistribution/appi
 ```
 appium server -ka 800 --use-plugins=device-farm --config ./serverConfig/hs-config.json
 or
-# In this with -pa case, please drop `/wd/hub` from 'url' in hs-config.jso
+# In this with -pa case, please drop `/wd/hub` from 'url' in hs-config.json
 appium server -ka 800 --use-plugins=device-farm --config ./serverConfig/hs-config.json -pa /wd/hub
 ```
 Refer on HeadSpin config [here](https://github.com/AppiumTestDistribution/appium-device-farm/blob/main/serverConfig/hs-config.json).

--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -38,5 +38,8 @@ Refer on LambdaTest config [here](https://github.com/AppiumTestDistribution/appi
 
 ```
 appium server -ka 800 --use-plugins=device-farm --config ./serverConfig/hs-config.json
+or
+# In this with -pa case, please drop `/wd/hub` from 'url' in hs-config.jso
+appium server -ka 800 --use-plugins=device-farm --config ./serverConfig/hs-config.json -pa /wd/hub
 ```
 Refer on HeadSpin config [here](https://github.com/AppiumTestDistribution/appium-device-farm/blob/main/serverConfig/hs-config.json).

--- a/serverConfig/hs-config.json
+++ b/serverConfig/hs-config.json
@@ -6,7 +6,7 @@
         "platform": "android",
         "cloud": {
           "cloudName": "headspin",
-          "url": "https://appium-canary.headspin.io/v0/api-token/wd/hub",
+          "url": "https://appium-dev.headspin.io/v0/api-token/wd/hub",
           "devices": [
             {
               "platformVersion": "12",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -79,7 +79,7 @@ export function nodeUrl(device: IDevice, basePath = ''): string {
     if (device.cloud.toLowerCase() === Cloud.PCLOUDY) {
       return `${host}/wd/hub`;
     } else if (device.cloud.toLowerCase() === Cloud.HEADSPIN) {
-      return `${host}` + basePath;
+      return `${host}${basePath}`;
     } else {
       return `https://${process.env.CLOUD_USERNAME}:${process.env.CLOUD_KEY}@${
         new URL(device.host).host

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -79,7 +79,7 @@ export function nodeUrl(device: IDevice, basePath = ''): string {
     if (device.cloud.toLowerCase() === Cloud.PCLOUDY) {
       return `${host}/wd/hub`;
     } else if (device.cloud.toLowerCase() === Cloud.HEADSPIN) {
-      return `${host}`;
+      return `${host}` + basePath;
     } else {
       return `https://${process.env.CLOUD_USERNAME}:${process.env.CLOUD_KEY}@${
         new URL(device.host).host


### PR DESCRIPTION
In current implementation, if the arg has `-pa`, requests add extra `-pa` value in addition to `url` in the config file. So for example the url is `https://appium-dev.headspin.io/v0/api-token/wd/hub`, all requests except for new session request could have `https://appium-dev.headspin.io/v0/api-token/wd/hub/wd/hub/session/...` with `-pa /wd/hub`.

So, with this change, users can add `-pa /wd/hub` for their arg. Then, they also should modify the config as `https://appium-dev.headspin.io/v0/api-token` to avoid the extra base path.

e.g.

```
appium server -ka 800 --use-plugins=device-farm --config ./serverConfig/hs-config.json -pa /wd/hub
```

with `"url": "https://appium-dev.headspin.io/v0/api-token"`, or

```
appium server -ka 800 --use-plugins=device-farm --config ./serverConfig/hs-config.json -pa /wd/hub
```
with `"url": "https://appium-dev.headspin.io/v0/api-token/wd/hub"`

HeadSpin provides with `/wd/hub` webdriver url by default, btw


