### PR TITLE
BREAKING CHANGE: Implement Dual Licensing Open Source MIT and Proprietary for Specific Components

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,40 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Appium Device Farm Plugin License
 
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+The Appium Device Farm Plugin is dual-licensed:
 
-1.  Definitions.
+1. Open Source Components License (MIT License)
 
-    "License" shall mean the terms and conditions for use, reproduction,
-    and distribution as defined by Sections 1 through 9 of this document.
+Copyright (c) 2024 Appium Test Distribution aka Appium Device Farm
 
-    "Licensor" shall mean the copyright owner or entity authorized by
-    the copyright owner that is granting the License.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-    "Legal Entity" shall mean the union of the acting entity and all
-    other entities that control, are controlled by, or are under common
-    control with that entity. For the purposes of this definition,
-    "control" means (i) the power, direct or indirect, to cause the
-    direction or management of such entity, whether by contract or
-    otherwise, or (ii) ownership of fifty percent (50%) or more of the
-    outstanding shares, or (iii) beneficial ownership of such entity.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-    "You" (or "Your") shall mean an individual or Legal Entity
-    exercising permissions granted by this License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
-    "Source" form shall mean the preferred form for making modifications,
-    including but not limited to software source code, documentation
-    source, and configuration files.
+This license applies to all files and directories in this project except those
+listed under "Proprietary Components" below.
 
-    "Object" form shall mean any form resulting from mechanical
-    transformation or translation of a Source form, including but
-    not limited to compiled object code, generated documentation,
-    and conversions to other media types.
+2. Proprietary Components
 
-    "Work" shall mean the work of authorship, whether in Source or
-    Object form, made available under the License, as indicated by a
-    copyright notice that is included in or attached to the work
-    (an example is provided in the Appendix below).
+The following components are proprietary and subject to the Appium Device Farm
+Proprietary License:
 
-    "Derivative Works" shall mean any work, whether in Source or Object
-    form, that is based on (or derived from) the Work and for which the
-    editorial revisions, annotations, elaborations, or other modifications
-    represent, as a whole, an original work of authorship. For the purposes
-    of this License, Derivative Works shall not include works that remain
-    separable from, or merely link (or bind by name) to the interfaces of,
-    the Work and Derivative Works thereof.
+- src/modules/dashboard
+- src/modules/device-control
+- dashboard-frontend
 
-    "Contribution" shall mean any work of authorship, including
-    the original version of the Work and any modifications or additions
-    to that Work or Derivative Works thereof, that is intentionally
-    submitted to Licensor for inclusion in the Work by the copyright owner
-    or by an individual or Legal Entity authorized to submit on behalf of
-    the copyright owner. For the purposes of this definition, "submitted"
-    means any form of electronic, verbal, or written communication sent
-    to the Licensor or its representatives, including but not limited to
-    communication on electronic mailing lists, source code control systems,
-    and issue tracking systems that are managed by, or on behalf of, the
-    Licensor for the purpose of discussing and improving the Work, but
-    excluding communication that is conspicuously marked or otherwise
-    designated in writing by the copyright owner as "Not a Contribution."
-
-    "Contributor" shall mean Licensor and any individual or Legal Entity
-    on behalf of whom a Contribution has been received by Licensor and
-    subsequently incorporated within the Work.
-
-2.  Grant of Copyright License. Subject to the terms and conditions of
-    this License, each Contributor hereby grants to You a perpetual,
-    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-    copyright license to reproduce, prepare Derivative Works of,
-    publicly display, publicly perform, sublicense, and distribute the
-    Work and such Derivative Works in Source or Object form.
-
-3.  Grant of Patent License. Subject to the terms and conditions of
-    this License, each Contributor hereby grants to You a perpetual,
-    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-    (except as stated in this section) patent license to make, have made,
-    use, offer to sell, sell, import, and otherwise transfer the Work,
-    where such license applies only to those patent claims licensable
-    by such Contributor that are necessarily infringed by their
-    Contribution(s) alone or by combination of their Contribution(s)
-    with the Work to which such Contribution(s) was submitted. If You
-    institute patent litigation against any entity (including a
-    cross-claim or counterclaim in a lawsuit) alleging that the Work
-    or a Contribution incorporated within the Work constitutes direct
-    or contributory patent infringement, then any patent licenses
-    granted to You under this License for that Work shall terminate
-    as of the date such litigation is filed.
-
-4.  Redistribution. You may reproduce and distribute copies of the
-    Work or Derivative Works thereof in any medium, with or without
-    modifications, and in Source or Object form, provided that You
-    meet the following conditions:
-
-    (a) You must give any other recipients of the Work or
-    Derivative Works a copy of this License; and
-
-    (b) You must cause any modified files to carry prominent notices
-    stating that You changed the files; and
-
-    (c) You must retain, in the Source form of any Derivative Works
-    that You distribute, all copyright, patent, trademark, and
-    attribution notices from the Source form of the Work,
-    excluding those notices that do not pertain to any part of
-    the Derivative Works; and
-
-    (d) If the Work includes a "NOTICE" text file as part of its
-    distribution, then any Derivative Works that You distribute must
-    include a readable copy of the attribution notices contained
-    within such NOTICE file, excluding those notices that do not
-    pertain to any part of the Derivative Works, in at least one
-    of the following places: within a NOTICE text file distributed
-    as part of the Derivative Works; within the Source form or
-    documentation, if provided along with the Derivative Works; or,
-    within a display generated by the Derivative Works, if and
-    wherever such third-party notices normally appear. The contents
-    of the NOTICE file are for informational purposes only and
-    do not modify the License. You may add Your own attribution
-    notices within Derivative Works that You distribute, alongside
-    or as an addendum to the NOTICE text from the Work, provided
-    that such additional attribution notices cannot be construed
-    as modifying the License.
-
-    You may add Your own copyright statement to Your modifications and
-    may provide additional or different license terms and conditions
-    for use, reproduction, or distribution of Your modifications, or
-    for any such Derivative Works as a whole, provided Your use,
-    reproduction, and distribution of the Work otherwise complies with
-    the conditions stated in this License.
-
-5.  Submission of Contributions. Unless You explicitly state otherwise,
-    any Contribution intentionally submitted for inclusion in the Work
-    by You to the Licensor shall be under the terms and conditions of
-    this License, without any additional terms or conditions.
-    Notwithstanding the above, nothing herein shall supersede or modify
-    the terms of any separate license agreement you may have executed
-    with Licensor regarding such Contributions.
-
-6.  Trademarks. This License does not grant permission to use the trade
-    names, trademarks, service marks, or product names of the Licensor,
-    except as required for reasonable and customary use in describing the
-    origin of the Work and reproducing the content of the NOTICE file.
-
-7.  Disclaimer of Warranty. Unless required by applicable law or
-    agreed to in writing, Licensor provides the Work (and each
-    Contributor provides its Contributions) on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    implied, including, without limitation, any warranties or conditions
-    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-    PARTICULAR PURPOSE. You are solely responsible for determining the
-    appropriateness of using or redistributing the Work and assume any
-    risks associated with Your exercise of permissions under this License.
-
-8.  Limitation of Liability. In no event and under no legal theory,
-    whether in tort (including negligence), contract, or otherwise,
-    unless required by applicable law (such as deliberate and grossly
-    negligent acts) or agreed to in writing, shall any Contributor be
-    liable to You for damages, including any direct, indirect, special,
-    incidental, or consequential damages of any character arising as a
-    result of this License or out of the use or inability to use the
-    Work (including but not limited to damages for loss of goodwill,
-    work stoppage, computer failure or malfunction, or any and all
-    other commercial damages or losses), even if such Contributor
-    has been advised of the possibility of such damages.
-
-9.  Accepting Warranty or Additional Liability. While redistributing
-    the Work or Derivative Works thereof, You may choose to offer,
-    and charge a fee for, acceptance of support, warranty, indemnity,
-    or other liability obligations and/or rights consistent with this
-    License. However, in accepting such obligations, You may act only
-    on Your own behalf and on Your sole responsibility, not on behalf
-    of any other Contributor, and only if You agree to indemnify,
-    defend, and hold each Contributor harmless for any liability
-    incurred by, or claims asserted against, such Contributor by reason
-    of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-Copyright [yyyy] [name of copyright owner]
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+For the full text of the proprietary license, see the accompanying
+PROPRIETARY-LICENSE.txt file.

--- a/PROPRIETARY-LICENSE.txt
+++ b/PROPRIETARY-LICENSE.txt
@@ -1,0 +1,46 @@
+APPIUM DEVICE FARM PLUGIN PROPRIETARY LICENSE
+
+1. License Grant
+   Subject to the terms and conditions of this License, the core maintainers of the Appium Device Farm Plugin project ("Licensors") hereby grant to you ("Licensee") a non-exclusive, non-transferable, limited license to use the proprietary components of the Appium Device Farm Plugin ("Proprietary Software") solely for your internal business purposes.
+
+2. Proprietary Components
+   This License applies exclusively to the following components of the Appium Device Farm Plugin:
+   - src/modules/dashboard
+   - src/modules/device-control
+   - dashboard-frontend
+
+3. Restrictions
+   Licensee shall not, and shall not permit others to:
+   a) Copy, modify, translate, adapt, alter, decompile, disassemble, or reverse engineer the Proprietary Software;
+   b) Create derivative works based on the Proprietary Software;
+   c) Distribute, sublicense, lease, rent, loan, or otherwise transfer the Proprietary Software to any third party;
+   d) Remove, alter, or obscure any proprietary notices on the Proprietary Software;
+   e) Use the Proprietary Software for any purpose other than as expressly permitted in this License.
+
+4. Ownership
+   Licensors retain all right, title, and interest in and to the Proprietary Software, including all intellectual property rights therein. This License does not grant Licensee any rights to patents, copyrights, trade secrets, trade names, trademarks, or any other rights in respect to the Proprietary Software.
+
+5. Confidentiality
+   Licensee acknowledges that the Proprietary Software contains valuable trade secrets of Licensor. Licensee agrees to maintain the confidentiality of the Proprietary Software and to use at least the same degree of care to prevent its unauthorized use or disclosure as Licensee uses with respect to its own confidential information.
+
+6. No Warranty
+   THE PROPRIETARY SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND. LICENSOR DISCLAIMS ALL WARRANTIES, WHETHER EXPRESS, IMPLIED, OR STATUTORY, INCLUDING WITHOUT LIMITATION ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
+
+7. Limitation of Liability
+   IN NO EVENT SHALL LICENSOR BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR DAMAGES FOR LOSS OF PROFITS, REVENUE, DATA, OR USE, INCURRED BY LICENSEE OR ANY THIRD PARTY, WHETHER IN AN ACTION IN CONTRACT OR TORT, EVEN IF SUCH PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+8. Termination
+   This License is effective until terminated. Licensor may terminate this License at any time if Licensee breaches any of its terms. Upon termination, Licensee shall immediately cease all use of the Proprietary Software and destroy all copies thereof.
+
+9. Export Compliance
+   Licensee shall comply with all applicable export laws and regulations in its use of the Proprietary Software.
+
+10. Governing Law and Jurisdiction
+    This License shall be governed by and construed in accordance with the laws of the jurisdiction where the majority of core maintainers reside, without giving effect to any choice of law rule. Any legal action or proceeding relating to this License shall be instituted in a court of competent jurisdiction in that same jurisdiction.
+
+By using the Proprietary Software, you acknowledge that you have read this License, understand it, and agree to be bound by its terms and conditions.
+
+Appium Device Farm Plugin Project
+https://github.com/AppiumTestDistribution/appium-device-farm
+
+Last Updated: 20/AUG/2024

--- a/PROPRIETARY-LICENSE.txt
+++ b/PROPRIETARY-LICENSE.txt
@@ -5,8 +5,7 @@ APPIUM DEVICE FARM PLUGIN PROPRIETARY LICENSE
 
 2. Proprietary Components
    This License applies exclusively to the following components of the Appium Device Farm Plugin:
-   - src/modules/dashboard
-   - src/modules/device-control
+   - src/modules/
    - dashboard-frontend
 
 3. Restrictions

--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ The Appium Device Farm Plugin uses a hybrid licensing model to balance open-sour
 2. **Proprietary Components**:
    The following components, while included in the distribution, are proprietary and provided in an obfuscated form:
 
-   - src/modules/dashboard
-   - src/modules/device-control
+   - src/modules/
    - dashboard-frontend
 
    These components are integral parts of the plugin but their source code is not open for modification or redistribution.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,39 @@ npm run build:docs
 
 Navigate to site directory and open index.html to view the site locally.
 
+## Licensing
+
+The Appium Device Farm Plugin uses a hybrid licensing model to balance open-source principles with the protection of certain proprietary components:
+
+1. **Open Source Components**:
+   The majority of this project is open source and licensed under the MIT License. This includes all files and directories except those explicitly listed as proprietary.
+
+2. **Proprietary Components**:
+   The following components, while included in the distribution, are proprietary and provided in an obfuscated form:
+
+   - src/modules/dashboard
+   - src/modules/device-control
+   - dashboard-frontend
+
+   These components are integral parts of the plugin but their source code is not open for modification or redistribution.
+
+### Using the Appium Device Farm Plugin
+
+The Appium Device Farm Plugin, including both open source and obfuscated proprietary components, is freely available for use under the terms specified in the LICENSE file. Users can utilize all functionalities provided by the plugin, including those powered by the proprietary components.
+
+### Important Notes on Proprietary Components
+
+- While the proprietary components are included in the distribution, their source code is not available for viewing, modification, or redistribution.
+- These components are provided in an obfuscated form to protect our intellectual property.
+- Users are granted the right to use these components as part of the Appium Device Farm Plugin, but not to decompile, reverse engineer, or attempt to extract the original source code.
+
+### Contributions and Modifications
+
+- Contributions and modifications to the open-source portions of the plugin are welcome.
+- Please note that it is not possible to contribute to or modify the proprietary components due to their obfuscated nature.
+
+For full license details, please see the [LICENSE](LICENSE) file in this repository. If you have any questions about the licensing or use of the Appium Device Farm Plugin, please open an issue in this repository.
+
 ## Thanks to contributors 💙
 
 <a href="https://github.com/AppiumTestDistribution/appium-device-farm/graphs/contributors">


### PR DESCRIPTION
BREAKING CHANGE:
This PR introduces a dual licensing model for the Appium Device Farm Plugin to clarify the usage terms for both open source and proprietary components:

- Updates LICENSE file to reflect MIT license for open source components
- Adds PROPRIETARY-LICENSE.txt for obfuscated, proprietary modules
- Updates README with clear explanation of licensing structure
- Ensures compliance with open source principles while protecting proprietary code

This change aims to provide transparency to users about component licensing while maintaining the project's integrity and protecting proprietary elements.