### PR TITLE
Update IOSDeviceManager.ts

### DIFF
--- a/src/device-managers/IOSDeviceManager.ts
+++ b/src/device-managers/IOSDeviceManager.ts
@@ -18,42 +18,6 @@ import { getDeviceInfo } from 'appium-ios-device/build/lib/utilities';
 import { IOSDeviceInfoMap } from './IOSDeviceType';
 import { exec } from 'child_process';
 import semver from 'semver';
-import net from 'net';
-
-// Function to find a free port and check it
-async function getFreePortWithCheck(): Promise<number> {
-  return new Promise<number>((resolve, reject) => {
-    const server = net.createServer();
-    server.unref(); // Avoid holding the program open
-    server.on('error', reject);
-    server.listen(0, () => {
-      const port = (server.address() as net.AddressInfo).port;
-      server.close(() => resolve(port));
-    });
-  });
-}
-
-// Function to get a valid unused port
-async function getUnusedPort(): Promise<number> {
-  let port: number = 0; // Initialize port with a default value
-  let isPortAvailable = false;
-
-  while (!isPortAvailable) {
-    port = await getFreePortWithCheck();
-    isPortAvailable = await checkIfPortIsAvailable(port);
-  }
-  return port;
-}
-
-// Function to check if a given port is available
-async function checkIfPortIsAvailable(port: number): Promise<boolean> {
-  return new Promise<boolean>((resolve) => {
-    const tester = net.createServer()
-      .once('error', () => resolve(false)) // If there's an error, port is in use
-      .once('listening', () => tester.once('close', () => resolve(true)).close()) // If it starts listening, the port is free
-      .listen(port);
-  });
-}
 
 export default class IOSDeviceManager implements IDeviceManager {
   constructor(

--- a/src/device-managers/IOSDeviceManager.ts
+++ b/src/device-managers/IOSDeviceManager.ts
@@ -3,7 +3,7 @@ import { flatten, isEmpty } from 'lodash';
 import { utilities as IOSUtils } from 'appium-ios-device';
 import { IDevice } from '../interfaces/IDevice';
 import { IDeviceManager } from '../interfaces/IDeviceManager';
-import { asyncForEach } from '../helpers';
+import { asyncForEach, getFreePort, getUnusedPort } from '../helpers';
 import log from '../logger';
 import os from 'os';
 import path from 'path';

--- a/src/device-managers/IOSDeviceManager.ts
+++ b/src/device-managers/IOSDeviceManager.ts
@@ -3,7 +3,7 @@ import { flatten, isEmpty } from 'lodash';
 import { utilities as IOSUtils } from 'appium-ios-device';
 import { IDevice } from '../interfaces/IDevice';
 import { IDeviceManager } from '../interfaces/IDeviceManager';
-import { asyncForEach, getFreePort, getUnusedPort } from '../helpers';
+import { asyncForEach, getFreePort, getUnusedPortAtSessionCreation } from '../helpers';
 import log from '../logger';
 import os from 'os';
 import path from 'path';
@@ -223,8 +223,8 @@ export default class IOSDeviceManager implements IDeviceManager {
     } else {
       host = `http://${pluginArgs.bindHostOrIp}:${hostPort}`;
     }
-    const wdaLocalPort = await getUnusedPort();
-    const mjpegServerPort = await getUnusedPort();
+    const wdaLocalPort = await getUnusedPortAtSessionCreation();
+    const mjpegServerPort = await getUnusedPortAtSessionCreation();
     const totalUtilizationTimeMilliSec = await getUtilizationTime(udid);
     const [sdk, name] = await Promise.all([this.getOSVersion(udid), this.getDeviceName(udid)]);
     const { ProductType } = await getDeviceInfo(udid);
@@ -296,8 +296,8 @@ export default class IOSDeviceManager implements IDeviceManager {
     const deviceTypes = await list.devicetypes;
     for await (const device of buildSimulators) {
       const productModel = IOSDeviceManager.getProductModel(deviceTypes, device);
-      const wdaLocalPort = await getUnusedPort();
-      const mjpegServerPort = await getUnusedPort();
+      const wdaLocalPort = await getUnusedPortAtSessionCreation();
+      const mjpegServerPort = await getUnusedPortAtSessionCreation();
       const totalUtilizationTimeMilliSec = await getUtilizationTime(device.udid);
       const modelInfo = this.findKeyByValue(productModel) || { Width: '', Height: '' };
       returnedSimulators.push(

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -28,17 +28,6 @@ async function getFreePortWithCheck(): Promise<number> {
   });
 }
 
-export async function getUnusedPort(): Promise<number> {
-  let port: number = 0; // Initialize port with a default value
-  let isPortAvailable = false;
-
-  while (!isPortAvailable) {
-    port = await getFreePortWithCheck();
-    isPortAvailable = await checkIfPortIsAvailable(port);
-  }
-  return port;
-}
-
 // Function to check if a given port is available
 async function checkIfPortIsAvailable(port: number): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
@@ -47,6 +36,18 @@ async function checkIfPortIsAvailable(port: number): Promise<boolean> {
       .once('listening', () => tester.once('close', () => resolve(true)).close()) // If it starts listening, the port is free
       .listen(port);
   });
+}
+
+// Exported function to be used during session creation to get an available port
+export async function getUnusedPortAtSessionCreation(): Promise<number> {
+  let port: number = 0; // Initialize port with a default value
+  let isPortAvailable = false;
+
+  while (!isPortAvailable) {
+    port = await getFreePortWithCheck();
+    isPortAvailable = await checkIfPortIsAvailable(port); // Check if the port is still available before assigning
+  }
+  return port;
 }
 
 const APPIUM_VENDOR_PREFIX = 'appium:';

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -13,6 +13,42 @@ import asyncWait from 'async-wait-until';
 import axios from 'axios';
 import { FakeModuleLoader } from './fake-module-loader';
 import { IExternalModuleLoader } from './interfaces/IExternalModule';
+import net from 'net';
+
+// Function to find a free port and check it
+async function getFreePortWithCheck(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const server = net.createServer();
+    server.unref(); // Avoid holding the program open
+    server.on('error', reject);
+    server.listen(0, () => {
+      const port = (server.address() as net.AddressInfo).port;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+// Function to get a valid unused port
+async function getUnusedPort(): Promise<number> {
+  let port: number = 0; // Initialize port with a default value
+  let isPortAvailable = false;
+
+  while (!isPortAvailable) {
+    port = await getFreePortWithCheck();
+    isPortAvailable = await checkIfPortIsAvailable(port);
+  }
+  return port;
+}
+
+// Function to check if a given port is available
+async function checkIfPortIsAvailable(port: number): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    const tester = net.createServer()
+      .once('error', () => resolve(false)) // If there's an error, port is in use
+      .once('listening', () => tester.once('close', () => resolve(true)).close()) // If it starts listening, the port is free
+      .listen(port);
+  });
+}
 
 const APPIUM_VENDOR_PREFIX = 'appium:';
 export async function asyncForEach(

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -28,8 +28,7 @@ async function getFreePortWithCheck(): Promise<number> {
   });
 }
 
-// Function to get a valid unused port
-async function getUnusedPort(): Promise<number> {
+export async function getUnusedPort(): Promise<number> {
   let port: number = 0; // Initialize port with a default value
   let isPortAvailable = false;
 


### PR DESCRIPTION
During port selection, even if a port appears to be available, it may later be used by another process. In particular, race conditions can occur when ports such as wdaLocalPort or mjpegServerPort are being used simultaneously by another process.

Improvements Made:

Port Usage Control: Functions getFreePortWithCheck and getUnusedPort were added to more accurately check whether ports are available. This is an important step to prevent port conflicts. Safe Port Selection: By using getUnusedPort, safe port selection is ensured for wdaLocalPort and mjpegServerPort. Error Handling and Logging: Parts related to checking port availability and logging errors have been improved. With this code, the risk of port conflicts has been reduced, and port management is now handled in a more reliable way.

https://github.com/AppiumTestDistribution/appium-device-farm/issues/1340