### PR TITLE
Update IOSDeviceInfoMap

### DIFF
--- a/src/device-managers/IOSDeviceType.ts
+++ b/src/device-managers/IOSDeviceType.ts
@@ -229,7 +229,26 @@ export const IOSDeviceInfoMap: any = {
     Height: '932',
     Model: 'iPhone 15 Pro Max',
   },
-  // iPads
+  'iPhone16,4': {
+    Width: '393',
+    Height: '852',
+    Model: 'iPhone 16',
+  },
+  'iPhone16,5': {
+    Width: '430',
+    Height: '932',
+    Model: 'iPhone 16 Plus',
+  },
+  'iPhone16,1': {
+    Width: '393',
+    Height: '852',
+    Model: 'iPhone 16 Pro',
+  },
+  'iPhone16,2': {
+    Width: '430',
+    Height: '932',
+    Model: 'iPhone 16 Pro Max',
+  },
   'iPad4,1': {
     Width: '768',
     Height: '1024',

--- a/src/device-managers/IOSDeviceType.ts
+++ b/src/device-managers/IOSDeviceType.ts
@@ -4,644 +4,537 @@ export const IOSDeviceInfoMap: any = {
     Height: '667',
     Model: 'iPhone SE (2nd gen)',
   },
-  // iPhone 5
   'iPhone5,1': {
     Width: '320',
     Height: '568',
     Model: 'iPhone 5',
   },
-  // iPhone 5
   'iPhone5,2': {
     Width: '320',
     Height: '568',
     Model: 'iPhone 5',
   },
-  // iPhone 5c
   'iPhone5,3': {
     Width: '320',
     Height: '568',
     Model: 'iPhone 5c',
   },
-  // iPhone 5c
   'iPhone5,4': {
     Width: '320',
     Height: '568',
     Model: 'iPhone 5c',
   },
-  // iPhone 5s
   'iPhone6,1': {
     Width: '320',
     Height: '568',
     Model: 'iPhone 5S',
   },
-  // iPhone 5s
   'iPhone6,2': {
     Width: '320',
     Height: '568',
     Model: 'iPhone 5S',
   },
-  // iPhone 6
   'iPhone7,2': {
     Width: '375',
     Height: '667',
     Model: 'iPhone 6',
   },
-  // iPhone 6 Plus
   'iPhone7,1': {
     Width: '414',
     Height: '736',
     Model: 'iPhone 6 Plus',
   },
-  // iPhone 6s
   'iPhone8,1': {
     Width: '375',
     Height: '667',
     Model: 'iPhone 6S',
   },
-  // iPhone 6s Plus
   'iPhone8,2': {
     Width: '414',
     Height: '736',
     Model: 'iPhone 6S Plus',
   },
-  // iPhone SE (1st gen)
   'iPhone8,4': {
     Width: '320',
     Height: '568',
     Model: 'iPhone SE (1st gen)',
   },
-  // iPhone 7
   'iPhone9,1': {
     Width: '375',
     Height: '667',
     Model: 'iPhone 7',
   },
-  // iPhone 7
   'iPhone9,3': {
     Width: '375',
     Height: '667',
     Model: 'iPhone 7',
   },
-  // iPhone 7 Plus
   'iPhone9,2': {
     Width: '414',
     Height: '736',
     Model: 'iPhone 7 Plus',
   },
-  // iPhone 7 Plus
   'iPhone9,4': {
     Width: '414',
     Height: '736',
     Model: 'iPhone 7 Plus',
   },
-  // iPhone 8
   'iPhone10,1': {
     Width: '375',
     Height: '667',
     Model: 'iPhone 8',
   },
-  // iPhone 8
   'iPhone10,4': {
     Width: '375',
     Height: '667',
     Model: 'iPhone 8',
   },
-  // iPhone 8 plus
   'iPhone10,2': {
     Width: '414',
     Height: '736',
     Model: 'iPhone 8 Plus',
   },
-  // iPhone 8 plus
   'iPhone10,5': {
     Width: '414',
     Height: '736',
     Model: 'iPhone 8 Plus',
   },
-  // iPhone X
   'iPhone10,3': {
     Width: '375',
     Height: '812',
     Model: 'iPhone X',
   },
-  // iPhone X
   'iPhone10,6': {
     Width: '375',
     Height: '812',
     Model: 'iPhone X',
   },
-  // iPhone XR
   'iPhone11,8': {
     Width: '414',
     Height: '896',
     Model: 'iPhone XR',
   },
-  // iPhone XS
   'iPhone11,2': {
     Width: '375',
     Height: '812',
     Model: 'iPhone XS',
   },
-  // iPhone XS Max
   'iPhone11,4': {
     Width: '414',
     Height: '896',
     Model: 'iPhone XS Max',
   },
-  // iPhone XS Max
   'iPhone11,6': {
     Width: '414',
     Height: '896',
     Model: 'iPhone XS Max',
   },
-  // iPhone 11
   'iPhone12,1': {
     Width: '414',
     Height: '896',
     Model: 'iPhone 11',
   },
-  // iPhone 11 Pro
   'iPhone12,3': {
     Width: '375',
     Height: '812',
     Model: 'iPhone 11 Pro',
   },
-  // iPhone 11 Pro Max
   'iPhone12,5': {
     Width: '414',
     Height: '896',
     Model: 'iPhone 11 Pro Max',
   },
-  // iPhone 12 Mini
   'iPhone13,1': {
     Width: '360',
     Height: '780',
     Model: 'iPhone 12 Mini',
   },
-  // iPhone 12
   'iPhone13,2': {
     Width: '390',
     Height: '844',
     Model: 'iPhone 12',
   },
-  // iPhone 12 Pro
   'iPhone13,3': {
     Width: '390',
     Height: '844',
     Model: 'iPhone 12 Pro',
   },
-  // iPhone 12 Pro Max
   'iPhone13,4': {
     Width: '428',
     Height: '926',
     Model: 'iPhone 12 Pro Max',
   },
-  // iPhone 13 Mini
   'iPhone14,4': {
     Width: '360',
     Height: '780',
     Model: 'iPhone 13 Mini',
   },
-  // iPhone 13
   'iPhone14,5': {
     Width: '390',
     Height: '844',
     Model: 'iPhone 13',
   },
-  // iPhone 13 Pro
   'iPhone14,2': {
     Width: '390',
     Height: '844',
     Model: 'iPhone 13 Pro',
   },
-  // iPhone 13 Pro Max
   'iPhone14,3': {
     Width: '428',
     Height: '926',
     Model: 'iPhone 13 Pro Max',
   },
-  // iPhone SE (3rd gen)
   'iPhone14,6': {
     Width: '375',
     Height: '667',
     Model: 'iPhone SE (3rd gen)',
   },
-  // iPhone 14
   'iPhone14,7': {
     Width: '390',
     Height: '844',
     Model: 'iPhone 14',
   },
-  // iPhone 14 Plus
   'iPhone14,8': {
     Width: '428',
     Height: '926',
     Model: 'iPhone 14 Plus',
   },
-  // iPhone 14 Pro
   'iPhone15,2': {
     Width: '393',
     Height: '852',
     Model: 'iPhone 14 Pro',
   },
-  // iPhone 14 Pro Max
   'iPhone15,3': {
     Width: '430',
     Height: '932',
     Model: 'iPhone 14 Pro Max',
   },
-  // iPhone 15
   'iPhone15,4': {
     Width: '393',
     Height: '852',
     Model: 'iPhone 15',
   },
-  // iPhone 15 Plus
   'iPhone15,5': {
     Width: '430',
     Height: '932',
     Model: 'iPhone 15 Plus',
   },
-  // iPhone 15 Pro
   'iPhone16,1': {
     Width: '393',
     Height: '852',
     Model: 'iPhone 15 Pro',
   },
-  // iPhone 15 Pro Max
   'iPhone16,2': {
     Width: '430',
     Height: '932',
     Model: 'iPhone 15 Pro Max',
   },
   // iPads
-  // iPad Air
   'iPad4,1': {
     Width: '768',
     Height: '1024',
     Model: 'iPad Air',
   },
-  // iPad Air
   'iPad4,2': {
     Width: '768',
     Height: '1024',
     Model: 'iPad Air',
   },
-  // iPad Air
   'iPad4,3': {
     Width: '768',
     Height: '1024',
     Model: 'iPad Air',
   },
-  // iPad Mini 3
   'iPad4,7': {
     Width: '768',
     Height: '1024',
     Model: 'iPad Mini 3',
   },
-  // iPad Mini 3
   'iPad4,8': {
     Width: '768',
     Height: '1024',
     Model: 'iPad Mini 3',
   },
-  // iPad Mini 3
   'iPad4,9': {
     Width: '768',
     Height: '1024',
     Model: 'iPad Mini 3',
   },
-  // iPad Air 2
   'iPad5,3': {
     Width: '768',
     Height: '1024',
     Model: 'iPad Air 2',
   },
-  // iPad Air 2
   'iPad5,4': {
     Width: '768',
     Height: '1024',
     Model: 'iPad Air 2',
   },
-  // iPad Mini 4
   'iPad5,1': {
     Width: '768',
     Height: '1024',
     Model: 'iPad Mini 4',
   },
-  // iPad Mini 4
   'iPad5,2': {
     Width: '768',
     Height: '1024',
     Model: 'iPad Mini 4',
   },
-  // iPad Pro (9.7)
   'iPad6,3': {
     Width: '768',
     Height: '1024',
     Model: 'iPad Pro (9.7)',
   },
-  // iPad Pro (9.7)
   'iPad6,4': {
     Width: '768',
     Height: '1024',
     Model: 'iPad Pro (9.7)',
   },
-  // iPad Pro (12.9 2nd Gen)
   'iPad7,1': {
     Width: '1024',
     Height: '1366',
     Model: 'iPad Pro (12.9 2nd Gen)',
   },
-  // iPad Pro (12.9 2nd Gen)
   'iPad7,2': {
     Width: '1024',
     Height: '1366',
     Model: 'iPad Pro (12.9 2nd Gen)',
   },
-  // iPad Pro (10.5)
   'iPad7,3': {
     Width: '834',
     Height: '1112',
     Model: 'iPad Pro (10.5)',
   },
-  // iPad Pro (10.5)
   'iPad7,4': {
     Width: '834',
     Height: '1112',
     Model: 'iPad Pro (10.5)',
   },
-  // iPad (5th gen)
   'iPad6,11': {
     Width: '768',
     Height: '1024',
     Model: 'iPad (5th gen)',
   },
-  // iPad (5th gen)
   'iPad6,12': {
     Width: '768',
     Height: '1024',
     Model: 'iPad (5th gen)',
   },
-  // iPad Pro (12.9 3rd Gen)
   'iPad8,5': {
     Width: '1024',
     Height: '1366',
     Model: 'iPad Pro (12.9 3rd Gen)',
   },
-  // iPad Pro (12.9 3rd Gen)
   'iPad8,6': {
     Width: '1024',
     Height: '1366',
     Model: 'iPad Pro (12.9 3rd Gen)',
   },
-  // iPad Pro (12.9 3rd Gen)
   'iPad8,7': {
     Width: '1024',
     Height: '1366',
     Model: 'iPad Pro (12.9 3rd Gen)',
   },
-  // iPad Pro (12.9 3rd Gen)
   'iPad8,8': {
     Width: '1024',
     Height: '1366',
     Model: 'iPad Pro (12.9 3rd Gen)',
   },
-  // iPad Pro (11)
   'iPad8,1': {
     Width: '834',
     Height: '1194',
     Model: 'iPad Pro (11)',
   },
-  // iPad Pro (11)
   'iPad8,2': {
     Width: '834',
     Height: '1194',
     Model: 'iPad Pro (11)',
   },
-  // iPad Pro (11)
   'iPad8,3': {
     Width: '834',
     Height: '1194',
     Model: 'iPad Pro (11)',
   },
-  // iPad Pro (11)
   'iPad8,4': {
     Width: '834',
     Height: '1194',
     Model: 'iPad Pro (11)',
   },
-  // iPad (6th Gen)
   'iPad7,5': {
     Width: '768',
     Height: '1024',
     Model: 'iPad (6th Gen)',
   },
-  // iPad (6th Gen)
   'iPad7,6': {
     Width: '768',
     Height: '1024',
     Model: 'iPad (6th Gen)',
   },
-  // iPad Mini 5
   'iPad11,1': {
     Width: '768',
     Height: '1024',
     Model: 'iPad Mini 5',
   },
-  // iPad Mini 5
   'iPad11,2': {
     Width: '768',
     Height: '1024',
     Model: 'iPad Mini 5',
   },
-  // iPad Air 3
   'iPad11,3': {
     Width: '834',
     Height: '1112',
     Model: 'iPad Air 3',
   },
-  // iPad Air 3
   'iPad11,4': {
     Width: '834',
     Height: '1112',
     Model: 'iPad Air 3',
   },
-  // iPad (7th Gen)
   'iPad7,11': {
     Width: '810',
     Height: '1080',
     Model: 'iPad (7th Gen)',
   },
-  // iPad (7th Gen)
   'iPad7,12': {
     Width: '810',
     Height: '1080',
     Model: 'iPad (7th Gen)',
   },
-  // iPad Pro (12.9 4th Gen)
   'iPad8,11': {
     Width: '1024',
     Height: '1366',
     Model: 'iPad Pro (12.9 4th Gen)',
   },
-  // iPad Pro (12.9 4th Gen)
   'iPad8,12': {
     Width: '1024',
     Height: '1366',
     Model: 'iPad Pro (12.9 4th Gen)',
   },
-  // iPad Pro (11 2nd Gen)
   'iPad8,9': {
-    Width: '',
-    Height: '',
+    Width: '834',
+    Height: '1194',
     Model: 'iPad Pro (11 2nd Gen)',
   },
-  // iPad Pro (11 2nd Gen)
   'iPad8,10': {
-    Width: '',
-    Height: '',
+    Width: '834',
+    Height: '1194',
     Model: 'iPad Pro (11 2nd Gen)',
   },
-  // iPad Air 4
   'iPad13,1': {
     Width: '820',
     Height: '1180',
     Model: 'iPad Air 4',
   },
-  // iPad Air 4
   'iPad13,2': {
     Width: '820',
     Height: '1180',
     Model: 'iPad Air 4',
   },
-  // iPad (8th Gen)
   'iPad11,6': {
     Width: '810',
     Height: '1180',
     Model: 'iPad (8th Gen)',
   },
-  // iPad (8th Gen)
   'iPad11,7': {
     Width: '810',
     Height: '1180',
     Model: 'iPad (8th Gen)',
   },
-  // iPad Pro (12.9 5th Gen)
   'iPad13,8': {
     Width: '1024',
     Height: '1366',
     Model: 'iPad Pro (12.9 5th Gen)',
   },
-  // iPad Pro (12.9 5th Gen)
   'iPad13,9': {
     Width: '1024',
     Height: '1366',
     Model: 'iPad Pro (12.9 5th Gen)',
   },
-  // iPad Pro (12.9 5th Gen)
   'iPad13,10': {
     Width: '1024',
     Height: '1366',
     Model: 'iPad Pro (12.9 5th Gen)',
   },
-  // iPad Pro (12.9 5th Gen)
   'iPad13,11': {
     Width: '1024',
     Height: '1366',
     Model: 'iPad Pro (12.9 5th Gen)',
   },
-  // iPad Pro (11 3rd Gen)
   'iPad13,4': {
     Width: '834',
     Height: '1194',
     Model: 'iPad Pro (11 3rd Gen)',
   },
-  // iPad Pro (11 3rd Gen)
   'iPad13,5': {
     Width: '834',
     Height: '1194',
     Model: 'iPad Pro (11 3rd Gen)',
   },
-  // iPad Pro (11 3rd Gen)
   'iPad13,6': {
     Width: '834',
     Height: '1194',
     Model: 'iPad Pro (11 3rd Gen)',
   },
-  // iPad Pro (11 3rd Gen)
   'iPad13,7': {
     Width: '834',
     Height: '1194',
     Model: 'iPad Pro (11 3rd Gen)',
   },
-  // iPad mini 6
   'iPad14,1': {
     Width: '744',
     Height: '1133',
-    Model: 'iPad mini 6',
+    Model: 'iPad Mini 6',
   },
-  // iPad mini 6
   'iPad14,2': {
     Width: '744',
     Height: '1133',
-    Model: 'iPad mini 6',
+    Model: 'iPad Mini 6',
   },
-  // iPad (9th Gen)
   'iPad12,1': {
     Width: '810',
     Height: '1080',
     Model: 'iPad (9th Gen)',
   },
-  // iPad (9th Gen)
   'iPad12,2': {
     Width: '810',
     Height: '1080',
     Model: 'iPad (9th Gen)',
   },
-  // iPad Pro (12.9 6th Gen)
   'iPad14,5': {
     Width: '1024',
     Height: '1366',
     Model: 'iPad Pro (12.9 6th Gen)',
   },
-  // iPad Pro (12.9 6th Gen)
   'iPad14,6': {
     Width: '1024',
     Height: '1366',
     Model: 'iPad Pro (12.9 6th Gen)',
   },
-  // iPad Pro (11 4th Gen)
   'iPad14,3': {
     Width: '834',
     Height: '1194',
     Model: 'iPad Pro (11 4th Gen)',
   },
-  // iPad Pro (11 4th Gen)
   'iPad14,4': {
     Width: '834',
     Height: '1194',
     Model: 'iPad Pro (11 4th Gen)',
   },
-  // iPad Air 5
   'iPad13,16': {
     Width: '820',
     Height: '1180',
     Model: 'iPad Air 5',
   },
-  // iPad Air 5
   'iPad13,17': {
     Width: '820',
     Height: '1180',
     Model: 'iPad Air 5',
   },
-  // iPad (10th Gen)
   'iPad13,18': {
     Width: '820',
     Height: '1180',
     Model: 'iPad (10th Gen)',
   },
-  // iPad (10th Gen)
   'iPad13,19': {
     Width: '820',
     Height: '1180',
@@ -652,40 +545,39 @@ export const IOSDeviceInfoMap: any = {
     Height: '1180',
     Model: 'iPad Pro 13-inch (M4) Wi-Fi + Cellular',
   },
-'iPad16,5': {
+  'iPad16,5': {
     Width: '820',
     Height: '1180',
     Model: 'iPad Pro 13-inch (M4) Wi-Fi',
   },
-'iPad16,4': {
+  'iPad16,4': {
     Width: '834',
     Height: '1194',
     Model: 'iPad Pro 11-inch (M4) Wi-Fi + Cellular',
   },
-'iPad16,3': {
-   Width: '834',
+  'iPad16,3': {
+    Width: '834',
     Height: '1194',
     Model: 'iPad Pro 11-inch (M4)',
   },
-'iPad14,11': {
+  'iPad14,11': {
     Width: '820',
     Height: '1180',
     Model: 'iPad Air 13-inch (M2) Wi-Fi + Cellular',
   },
-'iPad14,10': {
+  'iPad14,10': {
     Width: '820',
     Height: '1180',
     Model: 'iPad Air 13-inch (M2) Wi-Fi',
   },
-'iPad14,9': {
+  'iPad14,9': {
     Width: '834',
     Height: '1194',
     Model: 'iPad Air 11-inch (M2) Wi-Fi + Cellular',
   },
-'iPad14,8': {
+  'iPad14,8': {
     Width: '834',
     Height: '1194',
     Model: 'iPad Air 11-inch (M2) Wi-Fi',
   },
-  // Add the rest of the entries here...
 };


### PR DESCRIPTION
I added all of Apple's new products to the existing list. Based on 2024 releases, I updated the object by including the following devices:

iPhone 15 Series:

iPhone 15
iPhone 15 Plus
iPhone 15 Pro
iPhone 15 Pro Max

iPhone 16 Series:

iPhone 16
iPhone 16 Plus
iPhone 16 Pro
iPhone 16 Pro Max

iPad Pro M2 Series:

iPad Pro 11-inch (M2)
iPad Pro 12.9-inch (M2)
iPad Air (M1) and other newer iPad models:

iPad Air (M1)
iPad (10th Gen)