### PR TITLE
fix: enable livestream for android based on capability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appium-device-farm",
-  "version": "9.4.1",
+  "version": "9.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "appium-device-farm",
-      "version": "9.4.1",
+      "version": "9.4.2",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
Fixes #1429 