### PR TITLE
fix: provisioning profile file path after Xcode 16

### DIFF
--- a/documentation/docs/ios-signing.md
+++ b/documentation/docs/ios-signing.md
@@ -95,7 +95,12 @@ If you want to provide the custom path of WebDriverAgent project then set _WDA_P
 appium plugin run device-farm prepare-wda --wda-project-path=<path-to-WDA-project> --mobile-provisioning-file=<path-to-provision-profile>
 ```
 
-You should have all the provision certificates installed on your machine to build the WebDriverAgent from source in path.
+You should have all the provision certificates installed on your machine before building the WebDriverAgent from source. For Xcode versions 15 or below, ensure they are located in:
 ```
 ~/Library/MobileDevice/Provisioning\ Profiles
+```
+
+For Xcode versions 16 and above, place them in:
+```
+~/Library/Developer/Xcode/UserData/Provisioning\ Profiles
 ```


### PR DESCRIPTION
Hello,

I am a user of the `appium-device-farm` plugin and have been enjoying its capabilities.

After updating to Xcode 16 and using this plugin, I encountered an issue where building the `wda-resign.ipa` did not work correctly with newly added iOS real devices. Upon investigation, I found that starting from Xcode 16, the directory path where provisioning profiles are stored has changed. I resolved the issue by explicitly specifying the correct directory path during the WDA build process.

Since this project uses the `ios-mobileprovision-finder` library, I looked into its repository and noticed that a related PR addressing this issue was submitted 3 weeks ago. However, as it is unclear when the PR will be merged and a new version released, I decided to implement a temporary fix myself.

Please review my changes, and if there are no issues, I hope this can be merged to address the problem for others as well.

ref.
- https://github.com/xamarin/Xamarin.MacDev/pull/124
- https://github.com/NativeScript/ios-mobileprovision-finder/pull/18

Thank you!