### PR TITLE
fix: added missing nodeId for ios simulators when registered from node

### DIFF
--- a/src/device-managers/IOSDeviceManager.ts
+++ b/src/device-managers/IOSDeviceManager.ts
@@ -325,6 +325,7 @@ export default class IOSDeviceManager implements IDeviceManager {
           ),
           preBuildWDAPath: this.pluginArgs.preBuildWDAPath,
           tags: [],
+          nodeId: this.nodeId,
         }),
       );
     }


### PR DESCRIPTION
fixes #1461 