### PR TITLE
Call unblockDevice when terminating a session

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -630,6 +630,15 @@ class DevicePlugin extends BasePlugin {
         log.warn(`Error while releasing connection for device ${device.udid}. Error: ${err}`);
       }
     }
+    // add unblockDevice call
+    if (device?.udid && device?.host) {
+      try {
+        await unblockDevice(device.udid, device.host);
+        log.info(`Device ${device.udid} unblocked successfully.`);
+      } catch (err) {
+        log.warn(`Failed to unblock device ${device.udid}. Error: ${err}`);
+      }
+    }
     return res;
   }
 }


### PR DESCRIPTION
Occasionally, when a session is terminated, the device does not change to the "unblock" state. To address this, I have added a call to the unblock function when ending the session.

Please review it, and if there are no issues, please merge it. Thank you.