### PR TITLE
docs: Add comprehensive tvOS support documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 [![Build Status](https://dev.azure.com/saikrishna321/ATD/_apis/build/status/AppiumTestDistribution.appium-device-farm?branchName=main)](https://dev.azure.com/saikrishna321/ATD/_build/latest?definitionId=11&branchName=main) [![npm version](https://badge.fury.io/js/appium-device-farm.svg)](https://badge.fury.io/js/appium-device-farm)
 
-Appium Device-farm is a powerful plugin designed specifically to manage and streamline the creation of driver sessions for connected devices, including Android and iOS real devices, emulators, and simulators. This plugin extends the capabilities of Appium, making it easier for developers and testers to automate testing processes across a wide range of device types, ensuring that applications function smoothly in diverse environments.
+Appium Device-farm is a powerful plugin designed specifically to manage and streamline the creation of driver sessions for connected devices, including Android, iOS, and tvOS real devices, emulators, and simulators. This plugin extends the capabilities of Appium, making it easier for developers and testers to automate testing processes across a wide range of device types, ensuring that applications function smoothly in diverse environments.
 
 With Appium Device-farm, teams can:
 
-1. Remotely manage sessions for physical Android and iOS devices, emulators, and simulators, allowing for extensive cross-platform testing without the need for manual device handling.
+1. Remotely manage sessions for physical Android, iOS, and tvOS devices, emulators, and simulators, allowing for extensive cross-platform testing without the need for manual device handling.
 2. Automate test execution across multiple devices simultaneously, reducing the time and effort required to perform comprehensive application testing.
 3. Scale testing efforts to cover a broad array of device and OS combinations, ensuring that apps perform consistently across different hardware and software configurations.
 4. Integrate seamlessly with CI/CD pipelines to automate testing as part of continuous integration workflows, catching bugs and issues early in the development cycle.
@@ -120,6 +120,50 @@ The support and resources provided by the Appium device farm team were invaluabl
 
 The [Documentation](https://devicefarm.org/) is hosted separately at
 [Device Farm](https://devicefarm.org/)
+
+## 🍎 tvOS Support
+
+Appium Device-farm now supports Apple TV (tvOS) devices for comprehensive testing across Apple's ecosystem. To set up tvOS testing:
+
+### Prerequisites for tvOS Testing
+
+1. **Apple TV Device**: A physical Apple TV device with developer mode enabled
+2. **Mac with Xcode**: Required for signing the WebDriverAgent
+3. **Apple Developer Account**: For creating provisioning profiles
+4. **iOS Resigner App**: Download from [iOS Resigner GitHub](https://github.com/DanTheMan827/ios-app-signer/releases)
+
+### Setting up tvOS WebDriverAgent
+
+1. **Download WDA**: Get the WDA.ipa file from the [Appium Device Farm repository](https://github.com/AppiumTestDistribution/appium-device-farm/raw/main/WDA.ipa)
+
+2. **Create Provisioning Profile**: 
+   - Open Xcode and create a new project
+   - Ensure tvOS is selected as a supported platform
+   - Generate a provisioning profile that includes tvOS support
+
+3. **Resign WDA for tvOS**:
+   - Use the iOS Resigner app to resign the WDA.ipa
+   - **Important**: Save the output file as `wda-resign_tvos.ipa`
+   - Upload the resigned file to the device farm dashboard
+
+4. **Automatic Detection**: The device farm automatically detects and uses the appropriate WDA file:
+   - iOS devices (iPhone, iPad) → `wda-resign.ipa`
+   - tvOS devices (Apple TV) → `wda-resign_tvos.ipa`
+
+For detailed step-by-step instructions, see the [iOS Signing Documentation](https://devicefarm.org/ios-signing/).
+
+### tvOS Capabilities
+
+When creating sessions for tvOS devices, use the following capability:
+
+```json
+{
+  "appium:platformName": "tvOS",
+  "appium:platformVersion": "16.1.1"
+}
+```
+
+The device farm will automatically allocate tvOS devices and use the appropriate WebDriverAgent based on the platform specification.
 
 ## Contributing & Development
 

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -10,7 +10,7 @@ hide:
   <img src="assets/images/DeviceFarm-Logo.jpg" class="center" width="200"/>
 </div>
 
-This is an Appium plugin designed to manage and create driver session on connected android devices and iOS Simulators.
+This is an Appium plugin designed to manage and create driver sessions on connected Android devices, iOS simulators, and tvOS devices.
 
 :octicons-heart-fill-24:{ .heart } **Why Appium Device Farm?**
 
@@ -20,13 +20,13 @@ This is an Appium plugin designed to manage and create driver session on connect
 
 	---
 
-	Streamline your testing workflow for efficiency with our solution, which simplifies the setup and oversight of driver sessions on both iOS simulators and Android devices
+	Streamline your testing workflow for efficiency with our solution, which simplifies the setup and oversight of driver sessions on iOS simulators, tvOS devices, and Android devices
 
 -   :status-automated:{ .device } __Automated Device Recognition__
 
 	---
 
-	Enjoy a hassle-free testing experience as our system automatically detects connected Android and iOS devices—both simulators and real hardware—prior to session initiation.
+	Enjoy a hassle-free testing experience as our system automatically detects connected Android, iOS, and tvOS devices—both simulators and real hardware—prior to session initiation.
 
 -   :status-sync:{ .device } __Proactive Device Pool Management__
 

--- a/documentation/docs/ios-signing.md
+++ b/documentation/docs/ios-signing.md
@@ -1,10 +1,10 @@
 ---
-title: WebdriverAgent Signing with Xcode
+title: WebdriverAgent Signing with Xcode for iOS and tvOS
 hide:
   - navigation
 ---
 
-The Appium device farm now allows you to manage devices real IOS devices on non-Mac systems, including Raspberry Pi. To optimize its functionality, you need to re-sign the WebDriver agent with your provisioning profile and upload it to the device farm. The device farm will handle all the internal configuration. Below are the steps needed to sign the WebDriver agent.
+The Appium device farm now allows you to manage real iOS and tvOS devices on non-Mac systems, including Raspberry Pi. To optimize its functionality, you need to re-sign the WebDriver agent with your provisioning profile and upload it to the device farm. The device farm will handle all the internal configuration. Below are the steps needed to sign the WebDriver agent for both iOS and tvOS platforms.
 
 ## Prerequisite
 
@@ -73,6 +73,36 @@ After entering all the details, click "Start" and select a folder to save the re
 This will create a new file in the output directory.
 
 ![ios wda sign](https://raw.githubusercontent.com/AppiumTestDistribution/appium-device-farm/main/documentation/docs/assets/images/wda-signing/step14-wda-resign-completed.png)
+
+## Preparing WDA for tvOS Devices
+
+For tvOS devices (Apple TV), you need to create a separate resigned IPA file. The process is similar to iOS, but with some important differences:
+
+### Key Requirements for tvOS WDA:
+
+1. **Bundle ID**: tvOS apps require a different bundle identifier format. Make sure your provisioning profile includes tvOS support.
+
+2. **Provisioning Profile**: Your provisioning profile must explicitly support tvOS devices. When creating the provisioning profile in Xcode, ensure you select tvOS as a supported platform.
+
+3. **File Naming**: The resigned IPA must be named exactly `wda-resign_tvos.ipa` for the device farm to recognize it as a tvOS WebDriverAgent.
+
+### Steps for tvOS WDA Preparation:
+
+1. Follow the same provisioning profile creation steps as outlined above, but ensure tvOS is selected as a supported platform.
+
+2. Use the same WDA.ipa file from the [Appium Device Farm GitHub repository](https://github.com/AppiumTestDistribution/appium-device-farm/raw/main/WDA.ipa).
+
+3. In the iOS Resigner app:
+   - Select the WDA.ipa file as input
+   - Choose your Apple account from the Signing Certificate dropdown
+   - Select the tvOS-compatible provisioning profile
+   - **Important**: Save the output file as `wda-resign_tvos.ipa`
+
+4. Upload the `wda-resign_tvos.ipa` file to the device farm using the Apps section in the dashboard.
+
+The device farm will automatically detect and use the appropriate WDA file based on the connected device type:
+- iOS devices (iPhone, iPad) → `wda-resign.ipa`
+- tvOS devices (Apple TV) → `wda-resign_tvos.ipa`
 
 ## Uploading signed WDA in device farm
 

--- a/documentation/docs/setup.md
+++ b/documentation/docs/setup.md
@@ -44,13 +44,22 @@ User can block/unblock devices from Dashboard manually. These devices will not b
 
 Once automation picks the device user cannot manually unblock, it's responsible for the automation script.
 
-## Manual Control of Devices for iOS real device
+## Manual Control of Devices for iOS and tvOS real devices
+
+### For iOS Devices (iPhone, iPad)
 Resign the WDA provided here: [WDA](https://github.com/AppiumTestDistribution/appium-device-farm/blob/main/WDA.ipa). Upload the resigned WDA to the server from the UI. Make sure the WDA uploaded should be named as `wda-resign.ipa`.
 
 Follow the instructions [here](https://github.com/DanTheMan827/ios-app-signer) to resign the WDA.
 
 Verify: Install the resigned WDA on the device and check if the WDA is working fine. Use the command 
 `ios install --path=/pathto/wda-resign.ipa`
+
+### For tvOS Devices (Apple TV)
+For tvOS devices, you need to create a separate resigned WDA file. Use the same WDA.ipa file from the [Appium Device Farm GitHub repository](https://github.com/AppiumTestDistribution/appium-device-farm/blob/main/WDA.ipa).
+
+**Important**: When resigning for tvOS, ensure you save the output file as `wda-resign_tvos.ipa`. The device farm will automatically detect and use the appropriate WDA file based on the device platform.
+
+Follow the detailed instructions in the [iOS Signing Documentation](/ios-signing) for complete setup including provisioning profile creation and tvOS-specific requirements.
 ## Dashboard
 
 To reflect the test status on dashboard. 

--- a/documentation/docs/troubleshooting.md
+++ b/documentation/docs/troubleshooting.md
@@ -17,7 +17,7 @@ hide:
 1. run `appium plugin run device-farm reset`
 2. The above command will delete all the existing data from database and resets the device farm to the original state
 
-## IOS
+## iOS and tvOS
 
 1. How do I improve the iOS session startup for real device?
 
@@ -37,9 +37,16 @@ hide:
 2. How do I improve the iOS session startup for Simulators?
    - Provide server argument during the appium server start. `preBuildWDAPath` with the path to the WDA build for Simulators.
 
+3. How do I improve the tvOS session startup for real device?
+
+   - Resign the WDA provided here: [How to resign webdriver agent](/ios-signing) and save it as `wda-resign_tvos.ipa`
+   - Use the same capabilities as iOS devices
+   - Make sure the Apple TV device is unblocked and enabled developer mode
+   - Ensure your provisioning profile supports tvOS platform
+
 ## 📺 Streaming Settings
 
-The **Streaming Settings** section allows you to customize the streaming performance and quality of the IOS simulator and real device screen within the Appium Device-farm dashboard. This is particularly useful when accessing devices from remote machines for real-time control, ensuring the best balance between performance and visual clarity.
+The **Streaming Settings** section allows you to customize the streaming performance and quality of the iOS simulator, tvOS devices, and real device screens within the Appium Device-farm dashboard. This is particularly useful when accessing devices from remote machines for real-time control, ensuring the best balance between performance and visual clarity.
 
 ### 🔧 Settings Descriptions:
 


### PR DESCRIPTION
- Update iOS signing documentation to include tvOS support
- Add dedicated tvOS WDA preparation section with step-by-step instructions
- Update setup.md with tvOS device management instructions
- Enhance overview documentation to mention tvOS devices
- Add tvOS troubleshooting section
- Update README.md with complete tvOS setup guide
- Include tvOS capabilities examples and prerequisites
- Document automatic platform detection for iOS vs tvOS WDA files

This update provides comprehensive documentation for users wanting to test on Apple TV devices using the Appium Device Farm plugin.