### PR TITLE
chore: removed the return condition from the function in findAppPath

### DIFF
--- a/src/CapabilityManager.ts
+++ b/src/CapabilityManager.ts
@@ -39,7 +39,6 @@ function deleteAlwaysMatch(caps: ISessionCapability, capabilityName: string) {
 
 async function findAppPath(caps: any) {
   const mergedCaps = Object.assign({}, caps.firstMatch ? caps.firstMatch[0] : {}, caps.alwaysMatch);
-  if (mergedCaps['df:skipReport']) return;
   const fileName = mergedCaps['appium:app'];
   if (fileName?.startsWith('file')) {
     const appInfo: any = await prisma.appInformation.findFirst({


### PR DESCRIPTION
If we add the skipReport:True capability, then the app capability was not included in the final capabilities because there was a condition for exiting the findAppPath function.
`if (mergedCaps['df:skipReport']) return;`
all code
<img width="966" height="303" alt="Снимок экрана 2025-10-01 в 21 58 44" src="https://github.com/user-attachments/assets/7f26f7a6-46a8-45a9-810e-2b062bf83838" />


[issues-1760](https://github.com/AppiumTestDistribution/appium-device-farm/issues/1760)