### PR TITLE
fix: show block and unblock in the dashboard for admin users only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appium-device-farm",
-  "version": "11.0.2",
+  "version": "11.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appium-device-farm",
-      "version": "11.0.2",
+      "version": "11.0.6",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
This pull request updates the submodule reference for `dashboard-frontend` to point to a newer commit. No other changes are included.

Address #1795 

([dashboard-frontendL1-R1](diffhunk://#diff-1b4f3ae726fa110eb6200ecd7b6650899d0b42a7ac49d81589701304e16eef43L1-R1))