### PR TITLE
fix: Replace rmdirSync with rmSync for cacheDir

### DIFF
--- a/src/scripts/clear-assets.ts
+++ b/src/scripts/clear-assets.ts
@@ -145,7 +145,7 @@ async function main() {
   if (!hasSelectiveOptions) {
     console.log('No selective options provided, performing full reset...');
     if (fs.existsSync(config.cacheDir)) {
-      fs.rmdirSync(config.cacheDir, { recursive: true });
+      fs.rmSync(config.cacheDir, { recursive: true, force: true });
     }
     fs.mkdirSync(config.cacheDir, { recursive: true });
     executeCmd('npm run run-db-migration');


### PR DESCRIPTION
PR created in order to solve this error on reset script:
```
❯ appium plugin run device-farm reset
Using Metadata Path:  /Users/user/.cache/appium-device-farm
No selective options provided, performing full reset...
node:fs:1158
    throw new ERR_INVALID_ARG_VALUE(
          ^

TypeError [ERR_INVALID_ARG_VALUE]: The property 'options.recursive' is no longer supported. Received true
    at Object.rmdirSync (node:fs:1158:11)
    at /Users/user/.appium/node_modules/appium-device-farm/lib/src/scripts/clear-assets.js:143:30
    at Generator.next (<anonymous>)
    at fulfilled (/Users/user/.appium/node_modules/appium-device-farm/lib/src/scripts/clear-assets.js:5:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5) {
  code: 'ERR_INVALID_ARG_VALUE'
}

Node.js v25.2.1
Error: ✖ Encountered an error when running 'reset': Script exited with code 1
```

See more details here: https://github.com/AppiumTestDistribution/appium-device-farm/issues/1974#issuecomment-3601409669