### PR TITLE
fix: Remove NPM_TOKEN from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,5 +28,4 @@ jobs:
          - run: npx semantic-release
            env:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              NPM_TOKEN: ${{ secrets.npm_token }}
            name: Release


### PR DESCRIPTION
Remove NPM_TOKEN from the release step environment.