### PR TITLE
feat: using original filename in capability

### DIFF
--- a/src/CapabilityManager.ts
+++ b/src/CapabilityManager.ts
@@ -45,10 +45,17 @@ async function findAppPath(caps: any) {
       where: { uploadedFileName: fileName as string },
     });
     return `${DevicePlugin.serverUrl}${appInfo?.path}`;
+  } else if (fileName && /^[A-Za-z]+[A-Za-z0-9_\-\.]+\.(zip|apk|aab|ipa|app)$/.test(fileName)) {
+    const appInfo: any = await prisma.appInformation.findFirst({
+      where: { fileName: fileName as string },
+      orderBy: { createdAt: 'desc' },
+    });
+    return appInfo ? `${DevicePlugin.serverUrl}${appInfo?.path}` : fileName;
   } else {
     return fileName;
   }
 }
+
 export async function androidCapabilities(
   caps: ISessionCapability,
   freeDevice: IDevice,


### PR DESCRIPTION
## Description
Added an additional condition that checks if the file name exists in the files table. This enables referencing uploaded applications (APK/IPA) by their original names in the `appium:app` capability, instead of using automatically generated identifiers.

## Changes
 * Added condition to check for original file name presence in the table
 * Maintained compatibility with existing automatic naming functionality